### PR TITLE
[Feat] 기업 회원가입, 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,15 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-  implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
   implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
   runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
   runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseService.java
@@ -1,0 +1,8 @@
+package com.prototyne.Enterprise.service.EnterpriseService;
+
+import com.prototyne.Enterprise.web.dto.EnterpriseDto;
+
+public interface EnterpriseService {
+    EnterpriseDto.EnterpriseSignupResponse registerEnterprise(EnterpriseDto.EnterpriseSignupRequest enterpriseSignupRequest);
+    EnterpriseDto.EnterpriseLoginResponse loginEnterprise(EnterpriseDto.EnterpriseLoginRequest enterpriseLoginRequest);
+}

--- a/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseServiceImpl.java
@@ -1,0 +1,68 @@
+package com.prototyne.Enterprise.service.EnterpriseService;
+
+import com.prototyne.Enterprise.web.dto.EnterpriseDto;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.apiPayload.code.status.ErrorStatus;
+import com.prototyne.apiPayload.exception.handler.TempHandler;
+import com.prototyne.domain.Enterprise;
+import com.prototyne.repository.EnterpriseRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EnterpriseServiceImpl implements EnterpriseService {
+    private final EnterpriseRepository enterpriseRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtManager jwtManager;
+
+    @Override
+    public EnterpriseDto.EnterpriseSignupResponse registerEnterprise(EnterpriseDto.EnterpriseSignupRequest enterpriseSignupRequest) {
+        // 중복 사용자 체크
+        enterpriseRepository.findByUsername(enterpriseSignupRequest.getUsername())
+                .ifPresent(enterprise -> {throw new TempHandler(ErrorStatus.SIGNUP_DUPLICATE);
+                });
+
+        Enterprise enterprise=Enterprise.builder()
+                .username(enterpriseSignupRequest.getUsername())
+                .password(passwordEncoder.encode(enterpriseSignupRequest.getPassword()))
+                .name(enterpriseSignupRequest.getName())
+                .regNumber(enterpriseSignupRequest.getRegNumber())
+                .phone(enterpriseSignupRequest.getPhone())
+                .email(enterpriseSignupRequest.getEmail())
+                .address(enterpriseSignupRequest.getAddress())
+                .category(enterpriseSignupRequest.getCategory())
+                .size(enterpriseSignupRequest.getSize())
+                .status(enterpriseSignupRequest.getStatus())
+                .build();
+        Enterprise savedEnterprise = enterpriseRepository.save(enterprise);
+
+        return EnterpriseDto.EnterpriseSignupResponse.builder()
+                .enterpriseId(savedEnterprise.getId())
+                .msg("회원가입이 완료되었습니다.")
+                .build();
+    }
+
+    @Override
+    public EnterpriseDto.EnterpriseLoginResponse loginEnterprise(EnterpriseDto.EnterpriseLoginRequest enterpriseLoginRequest) {
+        // 사용자 조회
+        Enterprise enterprise = enterpriseRepository.findByUsername(enterpriseLoginRequest.getUsername())
+                .orElseThrow(()->new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
+        // 비밀번호 확인
+        if(!passwordEncoder.matches(enterpriseLoginRequest.getPassword(), enterprise.getPassword())){
+            throw new TempHandler(ErrorStatus.LOGIN_ERROR_ID); // 에러 status 변경하기
+        }
+
+        // JWT 토큰 생성
+        String accessToken = jwtManager.createJwt(enterprise.getId());
+
+        return EnterpriseDto.EnterpriseLoginResponse.builder()
+                .id(enterprise.getId())
+                .name(enterprise.getName())
+                .access_token(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseServiceImpl.java
@@ -53,7 +53,7 @@ public class EnterpriseServiceImpl implements EnterpriseService {
                 .orElseThrow(()->new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
         // 비밀번호 확인
         if(!passwordEncoder.matches(enterpriseLoginRequest.getPassword(), enterprise.getPassword())){
-            throw new TempHandler(ErrorStatus.LOGIN_ERROR_ID); // 에러 status 변경하기
+            throw new TempHandler(ErrorStatus.LOGIN_ERROR_PW);
         }
 
         // JWT 토큰 생성

--- a/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EnterpriseService/EnterpriseServiceImpl.java
@@ -19,6 +19,7 @@ public class EnterpriseServiceImpl implements EnterpriseService {
     private final PasswordEncoder passwordEncoder;
     private final JwtManager jwtManager;
 
+
     @Override
     public EnterpriseDto.EnterpriseSignupResponse registerEnterprise(EnterpriseDto.EnterpriseSignupRequest enterpriseSignupRequest) {
         // 중복 사용자 체크

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EnterpriseController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EnterpriseController.java
@@ -1,0 +1,38 @@
+package com.prototyne.Enterprise.web.controller;
+
+import com.prototyne.Enterprise.service.EnterpriseService.EnterpriseService;
+import com.prototyne.Enterprise.web.dto.EnterpriseDto;
+import com.prototyne.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/enterprise")
+@Tag(name = "${swagger.tag.test}")
+public class EnterpriseController {
+
+    private final EnterpriseService enterpriseService;
+
+    @PostMapping("/signup")
+    @Operation(summary = "기업 회원가입 API",
+            description = "기업 회원가입 API")
+    public ApiResponse<EnterpriseDto.EnterpriseSignupResponse> enterpriseSignup(@RequestBody @Valid EnterpriseDto.EnterpriseSignupRequest enterpriseSignupRequest) {
+        EnterpriseDto.EnterpriseSignupResponse response = enterpriseService.registerEnterprise(enterpriseSignupRequest);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "기업 로그인 API",
+            description = "기업 로그인 API")
+    public ApiResponse<EnterpriseDto.EnterpriseLoginResponse> enterpriseLogin(@RequestBody @Valid EnterpriseDto.EnterpriseLoginRequest enterpriseLoginRequest) {
+        EnterpriseDto.EnterpriseLoginResponse response = enterpriseService.loginEnterprise(enterpriseLoginRequest);
+        return ApiResponse.onSuccess(response);
+    }
+
+}

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EnterpriseController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EnterpriseController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/enterprise")
-@Tag(name = "${swagger.tag.test}")
+@Tag(name = "${swagger.tag.enterprise-auth}")
 public class EnterpriseController {
 
     private final EnterpriseService enterpriseService;

--- a/src/main/java/com/prototyne/Enterprise/web/dto/EnterpriseDto.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/EnterpriseDto.java
@@ -1,0 +1,47 @@
+package com.prototyne.Enterprise.web.dto;
+
+import com.prototyne.domain.enums.EnterpriseStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class EnterpriseDto {
+
+    @Builder
+    @Getter
+    public static class EnterpriseSignupRequest {
+        private String username;
+        private String password;
+        private String name;
+        private String regNumber;
+        private String phone;
+        private String email;
+        private String address;
+        private String category;
+        private String size;
+        private EnterpriseStatus status;
+    }
+
+    @Builder
+    @Getter
+    public static class EnterpriseLoginRequest {
+        private String username;
+        private String password;
+    }
+
+    @Builder
+    @Getter
+    public static class EnterpriseSignupResponse {
+        private Long enterpriseId;
+        private String msg;
+    }
+
+    @Builder
+    @Getter
+    public static class EnterpriseLoginResponse {
+        private Long id;
+        private String name;
+        private String access_token;
+    }
+}

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -16,6 +16,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     LOGIN_ERROR_ID(HttpStatus.BAD_REQUEST, "LOGIN4001", "존재하지 않는 유저입니다"),
+    LOGIN_ERROR_PW(HttpStatus.BAD_REQUEST, "LOGIN4002", "올바르지 않은 비밀번호입니다."),
     TOKEN_UNVALID(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다"),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN4002", "인증이 필요한 요청입니다"),
 

--- a/src/main/java/com/prototyne/apiPayload/config/SecurityConfig.java
+++ b/src/main/java/com/prototyne/apiPayload/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.prototyne.apiPayload.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf->csrf.disable())
+                .authorizeHttpRequests((requests)->requests
+                        .requestMatchers("/**", "/swagger-ui/**", "/v3/api-docs/**", "/enterprise/login", "/enterprise/signup").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/prototyne/domain/Enterprise.java
+++ b/src/main/java/com/prototyne/domain/Enterprise.java
@@ -1,6 +1,7 @@
 package com.prototyne.domain;
 
 import com.prototyne.domain.common.BaseEntity;
+import com.prototyne.domain.enums.EnterpriseStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,22 +19,30 @@ public class Enterprise extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
     @Column(nullable = false, length = 100)
     private String name;
 
     @Column(nullable = false, length = 50)
     private String regNumber;
 
-    @Column(nullable = true, length = 20)
     private String phone;
 
-    @Column(nullable = true, length = 20)
     private String email;
 
-    @Column(nullable = true, length = 512)
-    private String enterpriseDesc;
+    private String address;
 
-    private String thumbnailUrl;
+    private String category;
+
+    private String size;
+
+    @Enumerated(EnumType.STRING)
+    private EnterpriseStatus status;
 
     @OneToMany(mappedBy ="enterprise",cascade=CascadeType.ALL)
     private List<Product> productList=new ArrayList<>();

--- a/src/main/java/com/prototyne/domain/enums/EnterpriseStatus.java
+++ b/src/main/java/com/prototyne/domain/enums/EnterpriseStatus.java
@@ -1,0 +1,6 @@
+package com.prototyne.domain.enums;
+
+public enum EnterpriseStatus {
+    대기,
+    승인
+}

--- a/src/main/java/com/prototyne/repository/EnterpriseRepository.java
+++ b/src/main/java/com/prototyne/repository/EnterpriseRepository.java
@@ -1,0 +1,10 @@
+package com.prototyne.repository;
+
+import com.prototyne.domain.Enterprise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EnterpriseRepository extends JpaRepository<Enterprise, Long> {
+    Optional<Enterprise> findByUsername(String username);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,6 +105,7 @@ swagger:
     product-search: '08. 시제품 - 최근 검색어'
     like: '09. 좋아요(북마크)'
     alarm: '10. 알림'
+    enterprise-auth: '11. 기업 로그인/회원가입'
     test: 'A. Test API'
 
 spring-doc:


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#106 

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
- 기업 회원가입 api 구현 및 테스트
- 기업 로그인 api 구현 및 테스트

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 1. 기업 회원가입 `/enterprise/signup`
<img width="429" alt="엔터1" src="https://github.com/user-attachments/assets/b43230fe-9a5f-4252-9e1e-184c3bf6d8da">

(1) 회원가입 성공 시
<img width="360" alt="엔터2" src="https://github.com/user-attachments/assets/29a456d7-f9bf-4f92-a2d9-be2ad36ddb01">

-> db상에 비밀번호는 암호화된 값으로 저장
<img width="817" alt="엔터" src="https://github.com/user-attachments/assets/d3dd34a2-d1a9-4929-81d1-371d81ef1499">


(2) 회원가입 실패 시 (입력하는 id인 `username`은 중복 불가)
<img width="364" alt="엔터3" src="https://github.com/user-attachments/assets/ab72294a-6a11-4685-a937-7a8972360fd7">

### 2. 기업 로그인 `/enterprise/login`
<img width="361" alt="엔터4" src="https://github.com/user-attachments/assets/68241d03-a37e-4275-bf23-02f5abf4e644">

(1) 로그인 성공 시
-> 고유 id, 기업 이름(name), 액세스토큰 발급
<img width="334" alt="엔터5" src="https://github.com/user-attachments/assets/6d788bd6-68c3-423f-b6e6-ecbe3096a7f9">

(2) 로그인 실패 시 (아이디는 올바르고 비밀번호가 틀렸을 때)
<img width="367" alt="엔터6" src="https://github.com/user-attachments/assets/f5e63633-3aa7-40c1-95fd-b7e85079305e">

(3) 로그인 실패 시 (아이디가 올바르지 않을 때)
<img width="316" alt="엔터7" src="https://github.com/user-attachments/assets/5281b2f3-a92b-437f-93a9-a1ef8ac04897">

## 참고사항
회원가입/로그인을 위한 Security를 설정하면서 `SecurityConfig` 클래스를 만들었는데, 원래는 허용하는 경로를 지정해야 하다보니 접근이 안되거나 에러가 많이 발생해서 우선은 전체(`/**`)에 대해 permitAll()로 해두었습니다. 기업 계정 쪽 구현을 빠르게 완료해야 할 것 같아 우선 pr날리고 추후 더 찾아본 후 해당 부분은 수정하도록 하겠습니다!
