### PR TITLE
[Feat] 시제품 체험 목록 조회 api

### DIFF
--- a/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
@@ -1,0 +1,53 @@
+package com.prototyne.Enterprise.converter;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.domain.Event;
+import com.prototyne.domain.Product;
+
+import java.time.LocalDate;
+
+public class EventConverter {
+    // 체험 목록 조회 응답 형식으로
+    public static ProductDTO.EventResponse toEventResponse(Event event, Product product, LocalDate now) {
+        // 1. 체험(이벤트) 단계와 그에 따른 날짜 계산
+        ProductDTO.StageAndDate stageAndDate = calculateStageAndDate(event, now);
+
+        // 2. DTO 반환
+        return ProductDTO.EventResponse.builder()
+                .eventId(event.getId())
+                .thumbnailUrl(product.getThumbnailUrl())
+                .productName(product.getName())
+                .stageAndDate(stageAndDate)
+                .createdDate(event.getCreatedAt().toLocalDate())
+                .category(product.getCategory())
+                .build();
+    }
+
+    // 현재 날짜에 따라 체험(이벤트) 단계와 날짜 반환
+    public static ProductDTO.StageAndDate calculateStageAndDate(Event event, LocalDate now) {
+        Integer stage;
+        LocalDate stageDate;
+
+        if (now.isBefore(event.getEventStart().toLocalDate())) {
+            stage = 1; // 시작 전 -> 이벤트 시작일
+            stageDate = event.getEventStart().toLocalDate();
+        } else if (now.isBefore(event.getEventEnd().toLocalDate())) {
+            stage = 2; // 신청자 모집 기간 -> 이벤트 종료일
+            stageDate = event.getEventEnd().toLocalDate();
+        } else if (now.isBefore(event.getReleaseEnd().toLocalDate())) {
+            stage = 3; // 당첨자 발표 기간 -> 발표 종료일
+            stageDate = event.getReleaseEnd().toLocalDate();
+        } else if (now.isBefore(event.getFeedbackEnd().toLocalDate())) {
+            stage = 4; // 후기 작성 기간 -> 작성 종료일
+            stageDate = event.getFeedbackEnd().toLocalDate();// 작성 종료일
+        } else {
+            stage = 5; // 종료 -> 종료일
+            stageDate = event.getEndDate().toLocalDate();
+        }
+
+        return ProductDTO.StageAndDate.builder()
+                .stage(stage)
+                .stageDate(stageDate)
+                .build();
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
@@ -1,0 +1,20 @@
+package com.prototyne.Enterprise.converter;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.domain.Product;
+
+public class ProductConverter {
+    // 시제품 목록 조회 응답 형식으로
+    public static ProductDTO.ProductResponse toProductResponse(Product product) {
+        return ProductDTO.ProductResponse.builder()
+                .productId(product.getId())
+                .thumbnailUrl(product.getThumbnailUrl())
+                .productName(product.getName())
+                .reqTickets(product.getReqTickets())
+                .createdDate(product.getCreatedAt().toLocalDate())
+                .category(product.getCategory())
+                // 진행 중인 체험이 없다면 0
+                .eventCount(product.getEventList() != null ? product.getEventList().size() : 0)
+                .build();
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
@@ -1,0 +1,10 @@
+package com.prototyne.Enterprise.service.EventService;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+
+import java.util.List;
+
+public interface EventService {
+    // 기업 id에 따른 체험 목록 조회 (토큰 인증 필수)
+    List<ProductDTO.EventResponse> getEvents(String accessToken);
+}

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
@@ -1,0 +1,39 @@
+package com.prototyne.Enterprise.service.EventService;
+
+import com.prototyne.Enterprise.converter.EventConverter;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.domain.Event;
+import com.prototyne.repository.EventRepository;
+import com.prototyne.repository.ProductRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service("enterpriseEventServiceImpl")
+@AllArgsConstructor
+public class EventServiceImpl implements EventService {
+
+    private final JwtManager jwtManager;
+    private final ProductRepository productRepository;
+    private final EventRepository eventRepository;
+
+    // 체험 목록 조회
+    @Override
+    public List<ProductDTO.EventResponse> getEvents(String accessToken) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+        LocalDate now = LocalDate.now(); // 현재 날짜
+
+        // 1. 기업 ID로 모든 이벤트 조회
+        List<Event> events = eventRepository.findByEnterpriseId(enterpriseId);
+
+        /// 2. DTO 변환
+        return events.stream()
+                .map(event -> EventConverter.toEventResponse(event, event.getProduct(), now))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
@@ -1,0 +1,10 @@
+package com.prototyne.Enterprise.service.ProductService;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+
+import java.util.List;
+
+public interface ProductService {
+    // 기업 id에 따른 시제품 목록 조회 (토큰 인증 필수)
+    List<ProductDTO.ProductResponse> getProducts(String accessToken);
+}

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -1,0 +1,29 @@
+package com.prototyne.Enterprise.service.ProductService;
+
+import com.prototyne.Enterprise.converter.ProductConverter;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.domain.Product;
+import com.prototyne.repository.ProductRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final JwtManager jwtManager;
+    private final ProductRepository productRepository;
+
+    @Override
+    public List<ProductDTO.ProductResponse> getProducts(String accessToken) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+        List<Product> products = productRepository.findByEnterpriseId(enterpriseId);
+        return  products.stream()
+                .map(ProductConverter::toProductResponse) // 컨버터 메소드 호출
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -18,6 +18,7 @@ public class ProductServiceImpl implements ProductService {
     private final JwtManager jwtManager;
     private final ProductRepository productRepository;
 
+    // 시제품 목록 조회
     @Override
     public List<ProductDTO.ProductResponse> getProducts(String accessToken) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
@@ -1,0 +1,46 @@
+package com.prototyne.Enterprise.web.controller;
+
+import com.prototyne.Enterprise.service.EventService.EventService;
+import com.prototyne.Enterprise.service.ProductService.ProductService;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/enterprise")
+@Tag(name = "${swagger.tag.enterprise-event}")
+public class EventController {
+
+    private final JwtManager jwtManager;
+    private final EventService eventService;
+
+    // 체험 목록 조회
+    @GetMapping("/events")
+    @Operation(summary = "체험 목록 조회 API - 인증 필수" ,
+            description = "시제품 체험 목록 > 체험 목록" +"""
+        --- stageAndDate는 stage(단계)와 stageDate(그에 따른 날짜)로 구성
+
+        1: 시작 전              | 시작일             | event_start
+        2: 신청자 모집 기간     | 신청자 모집 종료    | event_end
+        3: 당첨자 발표 기간     | 당첨자 발표 종료    | release_end
+        4: 후기 작성 기간       | 후기 작성 종료      | feedback_end
+        5: 종료                 | 종료일             | end_date
+    """, security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<List<ProductDTO.EventResponse>> getEventsList(HttpServletRequest token) {
+        String oauthToken = jwtManager.getToken(token);
+        List<ProductDTO.EventResponse> eventList = eventService.getEvents(oauthToken);
+        return ApiResponse.onSuccess(eventList);
+    }
+
+}

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -1,0 +1,37 @@
+package com.prototyne.Enterprise.web.controller;
+
+import com.prototyne.Enterprise.service.ProductService.ProductService;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController("enterpriseProductController")
+@RequiredArgsConstructor
+@RequestMapping("/enterprise")
+@Tag(name = "${swagger.tag.enterprise-product}")
+public class ProductController {
+
+    private final JwtManager jwtManager;
+    private final ProductService productService;
+
+    // 시제품 목록 조회
+    @GetMapping("/products")
+    @Operation(summary = "시제품 목록 조회 API - 인증 필수" ,
+            description = "시제품 체험 목록 > 시제품 목록 \n ** 기업 로그인 상태 필수 **",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<List<ProductDTO.ProductResponse>> getEventsList(HttpServletRequest token) {
+        String oauthToken = jwtManager.getToken(token);
+        List<ProductDTO.ProductResponse> productList =  productService.getProducts(oauthToken);
+        return ApiResponse.onSuccess(productList);
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -27,11 +27,12 @@ public class ProductController {
     // 시제품 목록 조회
     @GetMapping("/products")
     @Operation(summary = "시제품 목록 조회 API - 인증 필수" ,
-            description = "시제품 체험 목록 > 시제품 목록 \n ** 기업 로그인 상태 필수 **",
+            description = "시제품 체험 목록 > 시제품 목록",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<List<ProductDTO.ProductResponse>> getEventsList(HttpServletRequest token) {
         String oauthToken = jwtManager.getToken(token);
         List<ProductDTO.ProductResponse> productList =  productService.getProducts(oauthToken);
         return ApiResponse.onSuccess(productList);
     }
+
 }

--- a/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
@@ -12,14 +12,32 @@ public class ProductDTO {
     @Builder
     @Getter
     public static class ProductResponse {
-        private Long productId;         // 시제품 아이디
-        private String thumbnailUrl;    // 시제품 썸네일
-        private String productName;     // 시제품 명
-        private Integer reqTickets;     // 시제품 필요 티켓 수
-        private LocalDate createdDate;  // 시제품 등록일
-        private ProductCategory category;   // 시제품 카테고리
-        private Integer eventCount;     // 진행 중인 체험
+        private final Long productId;         // 시제품 아이디
+        private final String thumbnailUrl;    // 시제품 썸네일
+        private final String productName;     // 시제품 명
+        private final Integer reqTickets;     // 시제품 필요 티켓 수
+        private final LocalDate createdDate;  // 시제품 등록일
+        private final ProductCategory category;   // 시제품 카테고리
+        private final Integer eventCount;     // 진행 중인 체험
 //        private LocalDate date;       // 출시 예정일
     }
 
+    // 체험 목록 조회 응답 형식
+    @Builder
+    @Getter
+    public static class EventResponse {
+        private final Long eventId;           // 체험(이벤트) 아이디
+        private final String thumbnailUrl;    // 시제품 썸네일
+        private final String productName;     // 시제품 명
+        private final StageAndDate stageAndDate;  // 체험(이벤트) 단계와 그에 따른 날짜
+        private final LocalDate createdDate;  // 체험(이벤트) 등록일
+        private final ProductCategory category;   // 시제품 카테고리
+    }
+
+    @Getter
+    @Builder
+    public static class StageAndDate {
+        private final Integer stage;       // 이벤트 단계
+        private final LocalDate stageDate;   // 단계에 따른 날짜
+    }
 }

--- a/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
@@ -1,0 +1,25 @@
+package com.prototyne.Enterprise.web.dto;
+
+import com.prototyne.domain.enums.ProductCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class ProductDTO {
+
+    // 시제품 목록 조회 응답 형식
+    @Builder
+    @Getter
+    public static class ProductResponse {
+        private Long productId;         // 시제품 아이디
+        private String thumbnailUrl;    // 시제품 썸네일
+        private String productName;     // 시제품 명
+        private Integer reqTickets;     // 시제품 필요 티켓 수
+        private LocalDate createdDate;  // 시제품 등록일
+        private ProductCategory category;   // 시제품 카테고리
+        private Integer eventCount;     // 진행 중인 체험
+//        private LocalDate date;       // 출시 예정일
+    }
+
+}

--- a/src/main/java/com/prototyne/Users/service/ProductService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/ProductService/EventServiceImpl.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Service
+@Service("usersEventServiceImpl")
 @RequiredArgsConstructor
 public class EventServiceImpl implements EventService {
 

--- a/src/main/java/com/prototyne/Users/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Users/web/controller/ProductController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RestController
+@RestController("usersProductController")
 @RequiredArgsConstructor
 @RequestMapping("/product")
 @Tag(name = "${swagger.tag.product}")

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -38,7 +38,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 로그인하지 않은 사용자가 북마크 여부 변경시
     HEART_ERROR_ID(HttpStatus.BAD_REQUEST, "HEART4001", "로그인이 필요합니다"),
-    // 존재하지 않는 이gi벤트의 북마크 여부 변경시
+    // 존재하지 않는 이벤트의 북마크 여부 변경시
     HEART_ERROR_EVENT(HttpStatus.BAD_REQUEST, "HEART4002", "잘못된 이벤트 접근입니다"),
 
     DATE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "FORMAT4001", "잘못된 날짜 형식입니다. 올바른 형식: yyyy-MM-dd"),
@@ -62,7 +62,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     TiCKET_LACK_ERROR(HttpStatus.BAD_REQUEST, "TiCKET4001", "티켓이 부족합니다."),
 
-    EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다.");
+    EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다."),
+
+    // 이벤트의 날짜가 null로 설정된 경우
+    EVENT_ERROR_DATE(HttpStatus.BAD_REQUEST,"EVENT4002","이벤트의 날짜가 null 입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/domain/Event.java
+++ b/src/main/java/com/prototyne/domain/Event.java
@@ -38,11 +38,12 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime feedbackEnd;
 
+    // 심사 중 필드
     @Column(nullable = false)
     private LocalDateTime judgeStart;
-
     @Column(nullable = false)
     private LocalDateTime judgeEnd;
+    //
 
     @Column(nullable = false)
     private LocalDateTime endDate;

--- a/src/main/java/com/prototyne/repository/EventRepository.java
+++ b/src/main/java/com/prototyne/repository/EventRepository.java
@@ -44,5 +44,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     // 카테고리에 따른 이벤트
     List<Event> findByProductCategory(ProductCategory category);
 
-    // 시제품 이벤트 id
+    // 기업 ID로 모든 이벤트 조회 (조인)
+    @Query("SELECT e FROM Event e JOIN FETCH e.product p WHERE p.enterprise.id = :enterpriseId")
+    List<Event> findByEnterpriseId(Long enterpriseId);
 }

--- a/src/main/java/com/prototyne/repository/ProductRepository.java
+++ b/src/main/java/com/prototyne/repository/ProductRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    // 기업 ID로 모든 시제품 조회
     List<Product> findByEnterpriseId(Long enterpriseId);
 }

--- a/src/main/java/com/prototyne/repository/ProductRepository.java
+++ b/src/main/java/com/prototyne/repository/ProductRepository.java
@@ -4,6 +4,9 @@ import com.prototyne.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findByEnterpriseId(Long enterpriseId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,7 @@ swagger:
     alarm: '10. 알림'
     enterprise-auth: '11. 기업 로그인/회원가입'
     enterprise-product: '12. 기업 시제품 - 조회, 등록, 삭제'
+    enterprise-event: '13. 기업 체험(이벤트) - 조회, 등록, 삭제'
     test: 'A. Test API'
 
 spring-doc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,6 +106,7 @@ swagger:
     like: '09. 좋아요(북마크)'
     alarm: '10. 알림'
     enterprise-auth: '11. 기업 로그인/회원가입'
+    enterprise-product: '12. 기업 시제품 - 조회, 등록, 삭제'
     test: 'A. Test API'
 
 spring-doc:


### PR DESCRIPTION
## 📌 관련 이슈
#114 

## ✨ PR 내용
# 시제품 목록 조회 api 구현 (GET /enterprise/products)
![image](https://github.com/user-attachments/assets/0270655f-fc96-4e8f-a210-c7d095bc8d83)
<img width="815" alt="1" src="https://github.com/user-attachments/assets/79959694-ec7e-4bce-945c-da4c1a3f0092">


# 체험 목록 조회 api 구현(GET /enterprise/events)
![image](https://github.com/user-attachments/assets/c876562c-af7f-4856-bae4-26c1675e4562)
- stage가 1인 경우 -> 시작 전 -> 시작일(event_start)
<img width="808" alt="2" src="https://github.com/user-attachments/assets/893eca41-8059-45c9-a179-8a7a6a62970d">
<img width="423" alt="3" src="https://github.com/user-attachments/assets/721f5c48-80b2-46ca-82f5-20436d28df50">

-  stage가 3인 경우 -> 당첨자 발표 기간 -> 당첨자 발표 종료일(release_end)
- stage가 2인 경우 -> 신청자 모집 기간 -> 신청자 모집 종료일(event_end)
<img width="514" alt="4" src="https://github.com/user-attachments/assets/43ec1ff9-1494-4834-be93-23c26b2fbbb0">
<img width="647" alt="5" src="https://github.com/user-attachments/assets/f7105f5a-8648-4a35-8ff0-c4a3c0ed0a51">
<img width="340" alt="6" src="https://github.com/user-attachments/assets/c67a5379-a795-44a6-b2e6-9db6a0c1cbf2">




# 환경변수 추가
![image](https://github.com/user-attachments/assets/7b70e8fd-4fd3-40dd-b1ed-b787418468fb)



## 📚 레퍼런스 혹은 궁금한 사항들
![image](https://github.com/user-attachments/assets/75a1da79-8f92-449c-b3ff-961d42d3a779)
출시예정일 필드 뺄지 말지 단톡방에 물어보기 (일단 빼서 구현) - 필요하면 추후 추가 예정
