### PR TITLE
[Feat] Kakaopay 결제 시스템 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
-
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
   implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
   runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/prototyne/Users/converter/PaymentConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/PaymentConverter.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 public class PaymentConverter {
     public Payment toEntity(User user, KakaoPayDto.KakaoPayRequest request){
         return Payment.builder()
-                .orderId(request.getOrderId())
+                .orderId(request.getPartnerOrderId())
                 .user(user)
                 .quantity(request.getQuantity())
                 .status(PaymentStatus.결제대기)

--- a/src/main/java/com/prototyne/Users/converter/PaymentConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/PaymentConverter.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 public class PaymentConverter {
     public Payment toEntity(User user, KakaoPayDto.KakaoPayRequest request){
         return Payment.builder()
-                .orderId(request.getPartnerOrderId())
+                .partnerOrderId(request.getPartnerOrderId())
                 .user(user)
                 .quantity(request.getQuantity())
                 .status(PaymentStatus.결제대기)

--- a/src/main/java/com/prototyne/Users/converter/PaymentConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/PaymentConverter.java
@@ -1,0 +1,25 @@
+package com.prototyne.Users.converter;
+
+import com.prototyne.Users.web.dto.KakaoPayDto;
+import com.prototyne.domain.Payment;
+import com.prototyne.domain.User;
+import com.prototyne.domain.enums.PaymentStatus;
+import com.prototyne.domain.enums.TicketOption;
+import lombok.Builder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Builder
+public class PaymentConverter {
+    public Payment toEntity(User user, KakaoPayDto.KakaoPayRequest request){
+        return Payment.builder()
+                .orderId(request.getOrderId())
+                .user(user)
+                .quantity(request.getQuantity())
+                .status(PaymentStatus.결제대기)
+                .amount(request.getTotalAmount())
+                .productName(request.getItemName())
+                .ticketOption(TicketOption.valueOf(request.getTicketOption()))
+                .build();
+    }
+}

--- a/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayProperties.java
+++ b/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayProperties.java
@@ -1,0 +1,22 @@
+package com.prototyne.Users.service.PaymentService;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "kakaopay")
+@Getter
+@Setter
+public class KakaopayProperties {
+    @Value("${spring.kakao.pay.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.kakao.pay.cid}")
+    private String cid;
+
+    @Value("${spring.server.liveServerIp}")
+    private String serverAddress;
+}

--- a/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayService.java
+++ b/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayService.java
@@ -6,6 +6,6 @@ import com.prototyne.domain.enums.TicketOption;
 public interface KakaopayService {
 
     KakaoPayDto.KakaoPayReadyResponse readyToPay(String accessToken, TicketOption ticketOption);
-    KakaoPayDto.KakaoPayApproveResponse approvePayment(String accessToken, String tid, String pgToken);
+    KakaoPayDto.KakaoPayApproveResponse approvePayment(String accessToken, String tid);
 
 }

--- a/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayService.java
+++ b/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayService.java
@@ -6,4 +6,6 @@ import com.prototyne.domain.enums.TicketOption;
 public interface KakaopayService {
 
     KakaoPayDto.KakaoPayReadyResponse readyToPay(String accessToken, TicketOption ticketOption);
+    KakaoPayDto.KakaoPayApproveResponse approvePayment(String accessToken, String tid, String pgToken);
+
 }

--- a/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/PaymentService/KakaopayServiceImpl.java
@@ -1,9 +1,17 @@
 package com.prototyne.Users.service.PaymentService;
 
+import com.prototyne.Users.converter.PaymentConverter;
 import com.prototyne.Users.service.LoginService.JwtManager;
 import com.prototyne.Users.web.dto.KakaoPayDto;
+import com.prototyne.apiPayload.code.status.ErrorStatus;
+import com.prototyne.apiPayload.exception.handler.TempHandler;
+import com.prototyne.domain.Payment;
+import com.prototyne.domain.User;
+import com.prototyne.domain.enums.PaymentStatus;
 import com.prototyne.domain.enums.TicketOption;
-import lombok.AllArgsConstructor;
+import com.prototyne.repository.PaymentRepository;
+import com.prototyne.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -11,11 +19,14 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class KakaopayServiceImpl implements KakaopayService {
 
     private final WebClient webClient;
     private final JwtManager jwtManager;
+    private final PaymentConverter paymentConverter;
+    private final UserRepository userRepository;
+    private final PaymentRepository paymentRepository;
 
     @Value("${spring.kakao.pay.admin-key}")
     private String adminKey;
@@ -28,9 +39,12 @@ public class KakaopayServiceImpl implements KakaopayService {
 
 
     @Autowired
-    public KakaopayServiceImpl(WebClient.Builder webClientBuilder, JwtManager jwtManager) {
+    public KakaopayServiceImpl(WebClient.Builder webClientBuilder, JwtManager jwtManager, PaymentConverter paymentConverter, UserRepository userRepository, PaymentRepository paymentRepository) {
         this.webClient = webClientBuilder.build();
         this.jwtManager = jwtManager;
+        this.paymentConverter = paymentConverter;
+        this.userRepository = userRepository;
+        this.paymentRepository = paymentRepository;
     }
 
     @Override
@@ -43,7 +57,7 @@ public class KakaopayServiceImpl implements KakaopayService {
         String failUrl = "http://" + serverAddress + "/payment/fail";
 
         MultiValueMap<String, String> requestBody = request.toMultiValueMap(cid, approvalUrl, cancelUrl, failUrl);
-        System.out.println("Request Body: " + requestBody);
+        Payment newPayment = savePaymentLogs(userId, request);
 
         return webClient.post()
                 .uri("https://kapi.kakao.com/v1/payment/ready")
@@ -52,20 +66,49 @@ public class KakaopayServiceImpl implements KakaopayService {
                 .bodyValue(request.toMultiValueMap(cid, approvalUrl, cancelUrl, failUrl))
                 .exchangeToMono(response -> {
                     if (response.statusCode().is4xxClientError()) {
-                        // 클라이언트 오류 로그 출력
+                        updatePaymentStatus(newPayment.getOrderId(), PaymentStatus.결제실패);
                         return response.bodyToMono(String.class).map(body -> {
                             throw new RuntimeException("4xx error: " + body);
                         });
                     } else if (response.statusCode().is5xxServerError()) {
-                        // 서버 오류 로그 출력
+                        updatePaymentStatus(newPayment.getOrderId(), PaymentStatus.결제실패);
                         return response.bodyToMono(String.class).map(body -> {
                             throw new RuntimeException("5xx error: " + body);
                         });
                     } else {
-                        // 정상 응답 처리
-                        return response.bodyToMono(KakaoPayDto.KakaoPayReadyResponse.class);
+                        return response.bodyToMono(KakaoPayDto.KakaoPayReadyResponse.class).map(readyResponse -> {
+                            updateToOngoingPaymentLogs(newPayment, readyResponse);
+                            return readyResponse;
+                        });
                     }
                 })
                 .block();
+    }
+
+    // step1. '결제 대기' 상태의 결제 기록 최초 생성
+    private Payment savePaymentLogs(Long userId, KakaoPayDto.KakaoPayRequest req){
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new TempHandler(ErrorStatus.PAYMENT_NO_USER_FOUND));
+
+        Payment payment = paymentConverter.toEntity(user, req);
+
+        return paymentRepository.save(payment);
+
+    }
+
+    // step 2. readyToPay()함수 호출 성공하여 response 제대로 반환 시,
+    // 반환되는 제휴사(카카오) 결제 id 결제 db에 저장 후 '결제 진행' 상태로 업데이트
+    private void updateToOngoingPaymentLogs(Payment payment, KakaoPayDto.KakaoPayReadyResponse res){
+        payment.setOrderId(res.getTid());
+        payment.setStatus(PaymentStatus.결제진행);
+        paymentRepository.save(payment);
+    }
+
+
+
+    private void updatePaymentStatus(String orderId, PaymentStatus status){
+        Payment originPayment = paymentRepository.findByOrderId(orderId);
+        originPayment.setStatus(status);
+        paymentRepository.save(originPayment);
     }
 }

--- a/src/main/java/com/prototyne/Users/web/controller/KakaopayController.java
+++ b/src/main/java/com/prototyne/Users/web/controller/KakaopayController.java
@@ -9,12 +9,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/kakaopay")
@@ -25,16 +23,29 @@ public class KakaopayController {
     private final KakaopayService kakaopayService;
     private final JwtManager jwtManager;
 
-    @Operation(summary= "카카오페이 결제 준비",
-                description = "카카오페이 결제 준비를 위해 userId와 ticketCount를 넘기면, " +
-                        "결제를 위한 TID와 결제 페이지로 redirect할 URL을 응답으로 받습니다.",
-                security = {@SecurityRequirement(name = "session-token")})
+    @Operation(summary = "카카오페이 결제 준비 API",
+            description = "카카오페이 결제 준비를 위해 userId와 ticketCount를 넘기면, " +
+                    "결제를 위한 TID와 결제 페이지로 redirect할 URL을 응답으로 받습니다.",
+            security = {@SecurityRequirement(name = "session-token")})
     @PostMapping("/ready")
     public ApiResponse<KakaoPayDto.KakaoPayReadyResponse> readyPay(
             HttpServletRequest request, @RequestParam TicketOption ticketOption) {
 
         String accessToken = jwtManager.getToken(request);
         KakaoPayDto.KakaoPayReadyResponse response = kakaopayService.readyToPay(accessToken, ticketOption);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "카카오페이 결제 승인 API",
+            description = "카카오페이 결제 승인을 위해, 받은 pg_token값으로 approval_url로 리다이렉트 됩니다.",
+            security = {@SecurityRequirement(name = "session-token")})
+    @PostMapping("/approve")
+    public ApiResponse<KakaoPayDto.KakaoPayApproveResponse> approvePay(
+            HttpServletRequest request,
+            @RequestBody @Valid KakaoPayDto.ApprovePaymentRequest approvePaymentRequest) {
+        String accessToken = jwtManager.getToken(request);
+        KakaoPayDto.KakaoPayApproveResponse response = kakaopayService.approvePayment(accessToken,
+                approvePaymentRequest.getTid(), approvePaymentRequest.getPgToken());
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/prototyne/Users/web/controller/KakaopayController.java
+++ b/src/main/java/com/prototyne/Users/web/controller/KakaopayController.java
@@ -32,10 +32,9 @@ public class KakaopayController {
     @PostMapping("/ready")
     public ApiResponse<KakaoPayDto.KakaoPayReadyResponse> readyPay(
             HttpServletRequest request, @RequestParam TicketOption ticketOption) {
+
         String accessToken = jwtManager.getToken(request);
         KakaoPayDto.KakaoPayReadyResponse response = kakaopayService.readyToPay(accessToken, ticketOption);
         return ApiResponse.onSuccess(response);
     }
-
-
 }

--- a/src/main/java/com/prototyne/Users/web/controller/KakaopayController.java
+++ b/src/main/java/com/prototyne/Users/web/controller/KakaopayController.java
@@ -4,12 +4,13 @@ import com.prototyne.Users.service.LoginService.JwtManager;
 import com.prototyne.Users.service.PaymentService.KakaopayService;
 import com.prototyne.Users.web.dto.KakaoPayDto;
 import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.apiPayload.code.status.ErrorStatus;
+import com.prototyne.apiPayload.exception.handler.TempHandler;
 import com.prototyne.domain.enums.TicketOption;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -36,16 +37,32 @@ public class KakaopayController {
         return ApiResponse.onSuccess(response);
     }
 
-    @Operation(summary = "카카오페이 결제 승인 API",
-            description = "카카오페이 결제 승인을 위해, 받은 pg_token값으로 approval_url로 리다이렉트 됩니다.",
+    @Operation(summary = "카카오페이 결제 성공 API",
+            description = "카카오페이 결제 승인을 위해, 받은 pg_token값을 넘겨주면, approval_url로 리다이렉트 되며 결제에 성공.",
             security = {@SecurityRequirement(name = "session-token")})
-    @PostMapping("/approve")
+    @PostMapping("/success")
     public ApiResponse<KakaoPayDto.KakaoPayApproveResponse> approvePay(
             HttpServletRequest request,
-            @RequestBody @Valid KakaoPayDto.ApprovePaymentRequest approvePaymentRequest) {
+            @RequestParam String pgToken) {
         String accessToken = jwtManager.getToken(request);
         KakaoPayDto.KakaoPayApproveResponse response = kakaopayService.approvePayment(accessToken,
-                approvePaymentRequest.getTid(), approvePaymentRequest.getPgToken());
+                 pgToken);
         return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "카카오페이 결제 취소 API",
+            description = "카카오페이 결제 진행 중 클라이언트가 결제를 취소했을 때 쓰이는 API",
+            security = {@SecurityRequirement(name = "session-token")})
+    @GetMapping("/cancel")
+    public void cancel(){
+        throw new TempHandler(ErrorStatus.PAYMENT_APPROVE_CANCEL);
+    }
+
+    @Operation(summary = "카카오페이 결제 실패 API",
+            description = "카카오페이 결제 진행 중 결제에 실패하였을 때 쓰이는 API",
+            security = {@SecurityRequirement(name = "session-token")})
+    @GetMapping("/fail")
+    public void fail(){
+        throw new TempHandler(ErrorStatus.PAYMENT_APPROVE_FAILURE);
     }
 }

--- a/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
+++ b/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
@@ -26,14 +26,16 @@ public class KakaoPayDto {
         private String itemName;
         private int quantity;
         private int totalAmount;
+        private String ticketOption;
 
 
         public KakaoPayRequest(Long userId, TicketOption ticketOption){
             this.orderId = UUID.randomUUID().toString();
             this.userId = userId;
-            this.itemName = ticketOption.getTicketNumber() + " 티켓 구매";
+            this.itemName = "[프로토타인] "+ticketOption.getTicketNumber() + " 티켓 구매";
             this.quantity = 1;
             this.totalAmount = ticketOption.getPrice();
+            this.ticketOption = String.valueOf(ticketOption);
         }
 
         public MultiValueMap<String, String> toMultiValueMap(String cid, String approvalUrl, String cancelUrl, String failUrl) {

--- a/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
+++ b/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
@@ -27,6 +27,7 @@ public class KakaoPayDto {
         private int quantity;
         private int totalAmount;
 
+
         public KakaoPayRequest(Long userId, TicketOption ticketOption){
             this.orderId = UUID.randomUUID().toString();
             this.userId = userId;
@@ -35,18 +36,18 @@ public class KakaoPayDto {
             this.totalAmount = ticketOption.getPrice();
         }
 
-        public MultiValueMap<String, String> toMutliValueMap() {
+        public MultiValueMap<String, String> toMultiValueMap(String cid, String approvalUrl, String cancelUrl, String failUrl) {
             MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-            map.add("cid", "TC0ONETIME");  // 테스트용 CID
+            map.add("cid", cid);  // 테스트용 CID
             map.add("partner_order_id", orderId);
             map.add("partner_user_id", userId.toString());
             map.add("item_name", itemName);
             map.add("quantity", String.valueOf(quantity));
             map.add("total_amount", String.valueOf(totalAmount));
             map.add("tax_free_amount", "0");
-            map.add("approval_url", "http://localhost:8080/payment/success");
-            map.add("cancel_url", "http://localhost:8080/payment/cancel");
-            map.add("fail_url", "http://localhost:8080/payment/fail");
+            map.add("approval_url", approvalUrl);
+            map.add("cancel_url", cancelUrl);
+            map.add("fail_url", failUrl);
             return map;
         }
     }

--- a/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
+++ b/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
@@ -1,9 +1,7 @@
 package com.prototyne.Users.web.dto;
 
 import com.prototyne.domain.enums.TicketOption;
-import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -21,7 +19,7 @@ public class KakaoPayDto {
 
     @Data
     public static class KakaoPayRequest {
-        private String orderId; // 결제 건 고유 번호
+        private String partnerOrderId; // 결제 건 고유 번호
         private Long userId;
         private String itemName;
         private int quantity;
@@ -30,7 +28,7 @@ public class KakaoPayDto {
 
 
         public KakaoPayRequest(Long userId, TicketOption ticketOption){
-            this.orderId = UUID.randomUUID().toString();
+            this.partnerOrderId = UUID.randomUUID().toString();
             this.userId = userId;
             this.itemName = "[프로토타인] "+ticketOption.getTicketNumber() + " 티켓 구매";
             this.quantity = 1;
@@ -41,7 +39,7 @@ public class KakaoPayDto {
         public MultiValueMap<String, String> toMultiValueMap(String cid, String approvalUrl, String cancelUrl, String failUrl) {
             MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
             map.add("cid", cid);  // 테스트용 CID
-            map.add("partner_order_id", orderId);
+            map.add("partner_order_id", partnerOrderId);
             map.add("partner_user_id", userId.toString());
             map.add("item_name", itemName);
             map.add("quantity", String.valueOf(quantity));
@@ -53,4 +51,42 @@ public class KakaoPayDto {
             return map;
         }
     }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class ApprovePaymentRequest {
+        private String cid;
+        private String tid; // kakaopay 발급
+        private Long userId;
+        private String pgToken;
+
+        public MultiValueMap<String, String> toMultiValueMap(){
+            MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+            map.add("cid", cid);
+            map.add("tid", tid);
+            map.add("partner_order_id", tid);
+            map.add("partner_user_id", userId.toString());
+            map.add("pg_token", pgToken);
+            return map;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class KakaoPayApproveResponse {
+        private String tid;
+        private String partner_order_id;
+        private String partner_user_id;
+        private String payment_method_type;
+        private Amount amount;
+        private String approved_at;
+        @Getter
+        @Setter
+        public static class Amount {
+            private int total;
+            private int vat;
+        }
+    }
+
 }

--- a/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
+++ b/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
@@ -61,40 +61,37 @@ public class KakaoPayDto {
     @Setter
     @AllArgsConstructor
     public static class ApprovePaymentRequest {
-        private String cid;
         private String tid; // kakaopay 발급
-        private Long userId;
         private String pgToken;
-
-        public Map<String, Object> toFormData() {
-            Map<String, Object> map = new HashMap<>();
-            {
-                map.put("cid", cid);
-                map.put("tid", tid);
-                map.put("partner_order_id", tid);
-                map.put("partner_user_id", userId.toString());
-                map.put("pg_token", pgToken);
-                return map;
-            }
-        }
     }
 
         @Getter
         @Setter
         @ToString
         public static class KakaoPayApproveResponse {
+            private String aid;
             private String tid;
+            private String cid;
             private String partner_order_id;
             private String partner_user_id;
             private String payment_method_type;
             private Amount amount;
+            private String item_name;
+            private String item_code;
+            private int quantity;
+            private String created_at; // 결제 요청
             private String approved_at;
+            private String payload;
 
             @Getter
             @Setter
             public static class Amount {
                 private int total;
-                private int vat;
+                private int tax_free;
+                private int tax;
+                private int point;
+                private int discount;
+                private int green_deposit;
             }
         }
 

--- a/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
+++ b/src/main/java/com/prototyne/Users/web/dto/KakaoPayDto.java
@@ -2,18 +2,23 @@ package com.prototyne.Users.web.dto;
 
 import com.prototyne.domain.enums.TicketOption;
 import lombok.*;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 public class KakaoPayDto {
 
     @Getter
     @Setter
-    public static class KakaoPayReadyResponse{
+    @Data
+    public static class KakaoPayReadyResponse {
         private String tid;
+        private String next_redirect_app_url;
+        private String next_redirect_mobile_url;
         private String next_redirect_pc_url;
+        private String android_app_scheme;
+        private String ios_app_scheme;
         private String created_at;
     }
 
@@ -27,27 +32,27 @@ public class KakaoPayDto {
         private String ticketOption;
 
 
-        public KakaoPayRequest(Long userId, TicketOption ticketOption){
+        public KakaoPayRequest(Long userId, TicketOption ticketOption) {
             this.partnerOrderId = UUID.randomUUID().toString();
             this.userId = userId;
-            this.itemName = "[프로토타인] "+ticketOption.getTicketNumber() + " 티켓 구매";
+            this.itemName = "[프로토타인] " + ticketOption.getTicketNumber() + " 티켓 구매";
             this.quantity = 1;
             this.totalAmount = ticketOption.getPrice();
             this.ticketOption = String.valueOf(ticketOption);
         }
 
-        public MultiValueMap<String, String> toMultiValueMap(String cid, String approvalUrl, String cancelUrl, String failUrl) {
-            MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-            map.add("cid", cid);  // 테스트용 CID
-            map.add("partner_order_id", partnerOrderId);
-            map.add("partner_user_id", userId.toString());
-            map.add("item_name", itemName);
-            map.add("quantity", String.valueOf(quantity));
-            map.add("total_amount", String.valueOf(totalAmount));
-            map.add("tax_free_amount", "0");
-            map.add("approval_url", approvalUrl);
-            map.add("cancel_url", cancelUrl);
-            map.add("fail_url", failUrl);
+        public Map<String, Object> toFormData(String cid, String approvalUrl, String cancelUrl, String failUrl) {
+            Map<String, Object> map = new HashMap<>();
+            map.put("cid", cid);  // 테스트용 CID
+            map.put("partner_order_id", partnerOrderId);
+            map.put("partner_user_id", userId.toString());
+            map.put("item_name", itemName);
+            map.put("quantity", String.valueOf(quantity));
+            map.put("total_amount", String.valueOf(totalAmount));
+            map.put("tax_free_amount", "0");
+            map.put("approval_url", approvalUrl);
+            map.put("cancel_url", cancelUrl);
+            map.put("fail_url", failUrl);
             return map;
         }
     }
@@ -61,32 +66,37 @@ public class KakaoPayDto {
         private Long userId;
         private String pgToken;
 
-        public MultiValueMap<String, String> toMultiValueMap(){
-            MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-            map.add("cid", cid);
-            map.add("tid", tid);
-            map.add("partner_order_id", tid);
-            map.add("partner_user_id", userId.toString());
-            map.add("pg_token", pgToken);
-            return map;
+        public Map<String, Object> toFormData() {
+            Map<String, Object> map = new HashMap<>();
+            {
+                map.put("cid", cid);
+                map.put("tid", tid);
+                map.put("partner_order_id", tid);
+                map.put("partner_user_id", userId.toString());
+                map.put("pg_token", pgToken);
+                return map;
+            }
         }
     }
 
-    @Getter
-    @Setter
-    public static class KakaoPayApproveResponse {
-        private String tid;
-        private String partner_order_id;
-        private String partner_user_id;
-        private String payment_method_type;
-        private Amount amount;
-        private String approved_at;
         @Getter
         @Setter
-        public static class Amount {
-            private int total;
-            private int vat;
+        @ToString
+        public static class KakaoPayApproveResponse {
+            private String tid;
+            private String partner_order_id;
+            private String partner_user_id;
+            private String payment_method_type;
+            private Amount amount;
+            private String approved_at;
+
+            @Getter
+            @Setter
+            public static class Amount {
+                private int total;
+                private int vat;
+            }
         }
-    }
+
 
 }

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -68,8 +68,9 @@ public enum ErrorStatus implements BaseErrorCode {
     PAYMENT_NO_ORDER_FOUND(HttpStatus.BAD_REQUEST, "PAYMENT4002", "유효하지 않은 결제 내역입니다."),
     PAYMENT_READY_CLIENT_FAILURE(HttpStatus.BAD_REQUEST, "PATYMENT4003", "결제 요청에 실패하였습니다."),
     PAYMENT_READY_SERVER_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT5001", "서버 에러, 결제 요청에 실패하였습니다."),
-    PAYMENT_APPROVE_FAILURE(HttpStatus.BAD_REQUEST, "PAYMENT4003", "결제 승인에 실패하였습니다.");
-
+    PAYMENT_APPROVE_FAILURE(HttpStatus.BAD_REQUEST, "PAYMENT4004", "결제 진행 중 실패하였습니다."),
+    PAYMENT_APPROVE_CANCEL(HttpStatus.BAD_REQUEST, "PAYMENT4005", "결제 진행 중 취소되었습니다."),
+    PAYMENT_INVALID_PGTOKEN(HttpStatus.BAD_REQUEST, "PAYMENT4006", "유효하지 않은 pg 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -65,7 +65,10 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다."),
 
     PAYMENT_NO_USER_FOUND(HttpStatus.BAD_REQUEST, "PAYMENT4001", "존재하지 않는 사용자의 결제 요청입니다."),
-    PAYMENT_NO_ORDER_FOUND(HttpStatus.BAD_REQUEST, "PAYMENT4002", "존재하지 않는 주문 건입니다.");
+    PAYMENT_NO_ORDER_FOUND(HttpStatus.BAD_REQUEST, "PAYMENT4002", "유효하지 않은 결제 내역입니다."),
+    PAYMENT_READY_CLIENT_FAILURE(HttpStatus.BAD_REQUEST, "PATYMENT4003", "결제 요청에 실패하였습니다."),
+    PAYMENT_READY_SERVER_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT5001", "서버 에러, 결제 요청에 실패하였습니다."),
+    PAYMENT_APPROVE_FAILURE(HttpStatus.BAD_REQUEST, "PAYMENT4003", "결제 승인에 실패하였습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -62,7 +62,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     TiCKET_LACK_ERROR(HttpStatus.BAD_REQUEST, "TiCKET4001", "티켓이 부족합니다."),
 
-    EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다.");
+    EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다."),
+
+    PAYMENT_NO_USER_FOUND(HttpStatus.BAD_REQUEST, "PAYMENT4001", "존재하지 않는 사용자의 결제 요청입니다."),
+    PAYMENT_NO_ORDER_FOUND(HttpStatus.BAD_REQUEST, "PAYMENT4002", "존재하지 않는 주문 건입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/domain/Payment.java
+++ b/src/main/java/com/prototyne/domain/Payment.java
@@ -22,7 +22,10 @@ public class Payment extends BaseEntity {
     private User user;
 
     @Column
-    private String orderId; //kakaoPay 연동 주문(결제) 고유 id
+    private String partnerOrderId;
+
+    @Column
+    private String tid; //kakaoPay 연동 주문(결제) 고유 id
 
     @Column(nullable = false, columnDefinition = "결제대기")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/prototyne/domain/Payment.java
+++ b/src/main/java/com/prototyne/domain/Payment.java
@@ -1,0 +1,43 @@
+package com.prototyne.domain;
+
+import com.prototyne.domain.common.BaseEntity;
+import com.prototyne.domain.enums.PaymentStatus;
+import com.prototyne.domain.enums.TicketOption;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Payment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @Column
+    private String orderId; //kakaoPay 연동 주문(결제) 고유 id
+
+    @Column(nullable = false, columnDefinition = "결제대기")
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status; // 결제 대기 -> 결제 진행 -> 결제 성공 / 결제 실패
+
+    @Column
+    private String productName; //결제 상품 이름
+
+    @Column(nullable = false)
+    private int quantity; // 결제 요청 1번 당 수량은 1개여야만 함
+
+    @Column(nullable = false)
+    private int amount; // 결제 금액
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TicketOption ticketOption; // 구매한 티켓 옵션
+}

--- a/src/main/java/com/prototyne/domain/enums/PaymentStatus.java
+++ b/src/main/java/com/prototyne/domain/enums/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.prototyne.domain.enums;
+
+public enum PaymentStatus {
+    결제대기,
+    결제진행,
+    결제성공,
+    결제실패
+
+}

--- a/src/main/java/com/prototyne/repository/PaymentRepository.java
+++ b/src/main/java/com/prototyne/repository/PaymentRepository.java
@@ -1,0 +1,13 @@
+package com.prototyne.repository;
+
+import com.prototyne.domain.Payment;
+import com.prototyne.domain.enums.PaymentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    List<Payment> findByStatusAndCreatedAtBefore(PaymentStatus paymentStatus, LocalDateTime timeOutTime);
+    Payment findByOrderId(String orderId);
+}

--- a/src/main/java/com/prototyne/repository/PaymentRepository.java
+++ b/src/main/java/com/prototyne/repository/PaymentRepository.java
@@ -1,17 +1,9 @@
 package com.prototyne.repository;
 
 import com.prototyne.domain.Payment;
-import com.prototyne.domain.enums.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
-    List<Payment> findByStatusAndCreatedAtBefore(PaymentStatus paymentStatus, LocalDateTime timeOutTime);
-    Payment findByOrderId(String orderId);
 
-    Payment findByIdAndOrderId(Long id, String orderId);
-
-    Payment findByUserIdAndOrderId(Long userId, String tid);
+    Payment findByUserIdAndTid(Long userId, String tid);
 }

--- a/src/main/java/com/prototyne/repository/PaymentRepository.java
+++ b/src/main/java/com/prototyne/repository/PaymentRepository.java
@@ -10,4 +10,8 @@ import java.util.List;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     List<Payment> findByStatusAndCreatedAtBefore(PaymentStatus paymentStatus, LocalDateTime timeOutTime);
     Payment findByOrderId(String orderId);
+
+    Payment findByIdAndOrderId(Long id, String orderId);
+
+    Payment findByUserIdAndOrderId(Long userId, String tid);
 }

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -17,4 +17,5 @@ spring:
   kakao:
     pay:
       admin-key: ${KAKAO_PAY_ADMIN_KEY}
+      secret-key: ${KAKAO_PAY_SECRET_KEY}
       cid: ${KAKAO_PAY_CID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
 
   server:
     env: blue
+    liveServerIp: 13.125.19.26
 
   config:
     import: optional:file:.env[.properties]


### PR DESCRIPTION
## 📌 관련 이슈
#111 

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
- 테스트 환경에서의 `cid` , `secret-key` 사용 → 추후 사업자 등록 후 실제 운영 환경으로 변경 예정(현재는 dev버전)
### 카카오페이 결제 요청 `POST /kakaopay/ready` 
- 요구사항에 맞게 커스텀한 ticketOption (티켓 5개: 5000원, 티켓 10개: 9000원, 티켓 20개: 16000원) 옵션 값을 요청
- 응답 값으로 카카오페이 결제로 리다이렉트할 수 있는 url 제공
![카카오페이 POST ready](https://github.com/user-attachments/assets/2a614992-24c5-4dca-9337-8b48ff054633)

**- 상기 응답되는 url 값으로 결제 진행 후, '결제' 버튼 클릭 시 pgToken값 발급**
![카카오페이 결제 완료 후 pgtoken 값 확인](https://github.com/user-attachments/assets/03d67539-3c05-45ca-8bdf-611c31d5d309)


### 카카오페이 결제 성공 `POST /kakaopay/success` 
- 결제 요청 후 성공 시, 반환되는 pgToken값으로 해당 url로 반환 
- 카카오톡으로 승인 내역 메시지 자동 전송
- 결제 내역 상태 '결제성공'으로 업데이트
![카카오페이 POST success](https://github.com/user-attachments/assets/b91b4c66-578e-4803-916f-731f10db8244)
![카카오페이 결제 성공시](https://github.com/user-attachments/assets/27edee06-b24f-478d-9f81-db86f61eb789)

![image](https://github.com/user-attachments/assets/6301c12f-4fe0-4acb-a637-122d2dd9d449)


## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
[kakaopay 공식 REST API 문서:온라인 결제-단건 결제](https://developers.kakaopay.com/docs/payment/online/single-payment)
※ 위의 문서를 참고하여 개발하였습니다. 

