### PR TITLE
[Feat] 시제품 등록 삭제 api 구현

### DIFF
--- a/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
@@ -1,6 +1,6 @@
 package com.prototyne.Enterprise.converter;
 
-import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Enterprise.web.dto.EventDTO;
 import com.prototyne.domain.Event;
 import com.prototyne.domain.Product;
 
@@ -8,12 +8,12 @@ import java.time.LocalDate;
 
 public class EventConverter {
     // 체험 목록 조회 응답 형식으로
-    public static ProductDTO.EventResponse toEventResponse(Event event, Product product, LocalDate now) {
+    public static EventDTO.EventResponse toEventResponse(Event event, Product product, LocalDate now) {
         // 1. 체험(이벤트) 단계와 그에 따른 날짜 계산
-        ProductDTO.StageAndDate stageAndDate = calculateStageAndDate(event, now);
+        EventDTO.StageAndDate stageAndDate = calculateStageAndDate(event, now);
 
         // 2. DTO 반환
-        return ProductDTO.EventResponse.builder()
+        return EventDTO.EventResponse.builder()
                 .eventId(event.getId())
                 .thumbnailUrl(product.getThumbnailUrl())
                 .productName(product.getName())
@@ -24,30 +24,45 @@ public class EventConverter {
     }
 
     // 현재 날짜에 따라 체험(이벤트) 단계와 날짜 반환
-    public static ProductDTO.StageAndDate calculateStageAndDate(Event event, LocalDate now) {
+    public static EventDTO.StageAndDate calculateStageAndDate(Event event, LocalDate now) {
         Integer stage;
         LocalDate stageDate;
 
-        if (now.isBefore(event.getEventStart().toLocalDate())) {
+        if (now.isBefore(event.getEventStart())) {
             stage = 1; // 시작 전 -> 이벤트 시작일
-            stageDate = event.getEventStart().toLocalDate();
-        } else if (now.isBefore(event.getEventEnd().toLocalDate())) {
+            stageDate = event.getEventStart();
+        } else if (now.isBefore(event.getReleaseStart())) {
             stage = 2; // 신청자 모집 기간 -> 이벤트 종료일
-            stageDate = event.getEventEnd().toLocalDate();
-        } else if (now.isBefore(event.getReleaseEnd().toLocalDate())) {
+            stageDate = event.getEventEnd();
+        } else if (now.isBefore(event.getFeedbackStart())) {
             stage = 3; // 당첨자 발표 기간 -> 발표 종료일
-            stageDate = event.getReleaseEnd().toLocalDate();
-        } else if (now.isBefore(event.getFeedbackEnd().toLocalDate())) {
+            stageDate = event.getReleaseEnd();
+        } else if (now.isBefore(event.getEndDate())) {
             stage = 4; // 후기 작성 기간 -> 작성 종료일
-            stageDate = event.getFeedbackEnd().toLocalDate();// 작성 종료일
+            stageDate = event.getFeedbackEnd();// 작성 종료일
         } else {
             stage = 5; // 종료 -> 종료일
-            stageDate = event.getEndDate().toLocalDate();
+            stageDate = event.getEndDate();
         }
 
-        return ProductDTO.StageAndDate.builder()
+        return EventDTO.StageAndDate.builder()
                 .stage(stage)
                 .stageDate(stageDate)
                 .build();
+    }
+
+    // 체험 엔티티 형식으로
+    public static Event toEvent(Product product, EventDTO.createEventRequest request) {
+        // 체험 생성
+        Event newEvent = Event.builder()
+                .product(product)
+                .eventStart(request.getEventStart())
+                .eventEnd(request.getEventEnd())
+                .releaseStart(request.getReleaseStart())
+                .releaseEnd(request.getReleaseEnd())
+                .feedbackStart(request.getFeedbackStart())
+                .feedbackEnd(request.getFeedbackEnd())
+                .build();
+        return newEvent;
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
@@ -1,0 +1,53 @@
+package com.prototyne.Enterprise.converter;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.domain.Event;
+import com.prototyne.domain.Product;
+
+import java.time.LocalDate;
+
+public class EventConverter {
+    // 체험 목록 조회 응답 형식으로
+    public static ProductDTO.EventResponse toEventResponse(Event event, Product product, LocalDate now) {
+        // 1. 체험(이벤트) 단계와 그에 따른 날짜 계산
+        ProductDTO.StageAndDate stageAndDate = calculateStageAndDate(event, now);
+
+        // 2. DTO 반환
+        return ProductDTO.EventResponse.builder()
+                .eventId(event.getId())
+                .thumbnailUrl(product.getThumbnailUrl())
+                .productName(product.getName())
+                .stageAndDate(stageAndDate)
+                .createdDate(event.getCreatedAt().toLocalDate())
+                .category(product.getCategory())
+                .build();
+    }
+
+    // 현재 날짜에 따라 체험(이벤트) 단계와 날짜 반환
+    public static ProductDTO.StageAndDate calculateStageAndDate(Event event, LocalDate now) {
+        Integer stage;
+        LocalDate stageDate;
+
+        if (now.isBefore(event.getEventStart().toLocalDate())) {
+            stage = 1; // 시작 전 -> 이벤트 시작일
+            stageDate = event.getEventStart().toLocalDate();
+        } else if (now.isBefore(event.getEventEnd().toLocalDate())) {
+            stage = 2; // 신청자 모집 기간 -> 이벤트 종료일
+            stageDate = event.getEventEnd().toLocalDate();
+        } else if (now.isBefore(event.getReleaseEnd().toLocalDate())) {
+            stage = 3; // 당첨자 발표 기간 -> 발표 종료일
+            stageDate = event.getReleaseEnd().toLocalDate();
+        } else if (now.isBefore(event.getFeedbackEnd().toLocalDate())) {
+            stage = 4; // 후기 작성 기간 -> 작성 종료일
+            stageDate = event.getFeedbackEnd().toLocalDate();// 작성 종료일
+        } else {
+            stage = 5; // 종료 -> 종료일
+            stageDate = event.getEndDate().toLocalDate();
+        }
+
+        return ProductDTO.StageAndDate.builder()
+                .stage(stage)
+                .stageDate(stageDate)
+                .build();
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
@@ -37,12 +37,12 @@ public class EventConverter {
         } else if (now.isBefore(event.getFeedbackStart())) {
             stage = 3; // 당첨자 발표 기간 -> 발표 종료일
             stageDate = event.getReleaseEnd();
-        } else if (now.isBefore(event.getEndDate())) {
+        } else if (now.isBefore(event.getFeedbackEnd()) || now.isEqual(event.getFeedbackEnd())) {
             stage = 4; // 후기 작성 기간 -> 작성 종료일
             stageDate = event.getFeedbackEnd();// 작성 종료일
         } else {
             stage = 5; // 종료 -> 종료일
-            stageDate = event.getEndDate();
+            stageDate = event.getFeedbackEnd().plusDays(1);;
         }
 
         return EventDTO.StageAndDate.builder()

--- a/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
@@ -1,10 +1,13 @@
 package com.prototyne.Enterprise.converter;
 
 import com.prototyne.Enterprise.web.dto.EventDTO;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
 import com.prototyne.domain.Event;
 import com.prototyne.domain.Product;
+import com.prototyne.domain.ProductImage;
 
 import java.time.LocalDate;
+import java.util.stream.Collectors;
 
 public class EventConverter {
     // 체험 목록 조회 응답 형식으로
@@ -42,7 +45,7 @@ public class EventConverter {
             stageDate = event.getFeedbackEnd();// 작성 종료일
         } else {
             stage = 5; // 종료 -> 종료일
-            stageDate = event.getFeedbackEnd().plusDays(1);;
+            stageDate = event.getFeedbackEnd().plusDays(1);
         }
 
         return EventDTO.StageAndDate.builder()
@@ -52,9 +55,9 @@ public class EventConverter {
     }
 
     // 체험 엔티티 형식으로
-    public static Event toEvent(Product product, EventDTO.createEventRequest request) {
-        // 체험 생성
-        Event newEvent = Event.builder()
+    public static Event toEvent(Product product, EventDTO.EventDate request) {
+        // 체험 생성 및 반환
+        return Event.builder()
                 .product(product)
                 .eventStart(request.getEventStart())
                 .eventEnd(request.getEventEnd())
@@ -63,6 +66,40 @@ public class EventConverter {
                 .feedbackStart(request.getFeedbackStart())
                 .feedbackEnd(request.getFeedbackEnd())
                 .build();
-        return newEvent;
+    }
+
+    // 체험 정보 형식으로
+    public static EventDTO.EventInfo toEventInfo(Product product, Event event) {
+        // 시제품 정보
+        ProductDTO.ProductInfo productInfo = ProductDTO.ProductInfo.builder()
+                .productName(product.getName())
+                .contents(product.getContents())
+                .reqTickets(product.getReqTickets())
+                .notes(product.getNotes())
+                .category(product.getCategory())
+                .build();
+
+        // 체험 정보
+        EventDTO.EventDate eventDate = EventDTO.EventDate.builder()
+                .eventStart(event.getEventStart())
+                .eventEnd(event.getEventEnd())
+                .releaseStart(event.getReleaseStart())
+                .releaseEnd(event.getReleaseEnd())
+                .feedbackStart(event.getFeedbackStart())
+                .feedbackEnd(event.getFeedbackEnd())
+                .build();
+
+        // DTO 반환
+        return EventDTO.EventInfo.builder()
+                .productId(product.getId())
+                .eventId(event.getId())
+                .productImages( // 이미지 url 추출. 없으면 null 반환
+                        product.getProductImageList() != null && !product.getProductImageList().isEmpty()
+                        ? product.getProductImageList().stream()
+                        .map(ProductImage::getImageUrl).collect(Collectors.toList())
+                        : null)
+                .productInfo(productInfo)
+                .dates(eventDate)
+                .build();
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
@@ -28,17 +28,20 @@ public class ProductConverter {
                                     Enterprise enterprise,
                                     List<String> imageUrls) {
         // Product 생성
+        ProductDTO.ProductInfo productInfo = request.getProductInfo();
+        ProductDTO.Questions questions = request.getQuestions();
+
         Product newProduct = Product.builder()
-                .name(request.getProductName())
-                .contents(request.getContents())
-                .reqTickets(request.getReqTickets())
-                .notes(request.getNotes())
-                .category(request.getCategory())
-                .question1(request.getQuestions().getQuestion1())
-                .question2(request.getQuestions().getQuestion2())
-                .question3(request.getQuestions().getQuestion3())
-                .question4(request.getQuestions().getQuestion4())
-                .question5(request.getQuestions().getQuestion5())
+                .name(productInfo.getProductName())
+                .contents(productInfo.getContents())
+                .reqTickets(productInfo.getReqTickets())
+                .notes(productInfo.getNotes())
+                .category(productInfo.getCategory())
+                .question1(questions.getQuestion1())
+                .question2(questions.getQuestion2())
+                .question3(questions.getQuestion3())
+                .question4(questions.getQuestion4())
+                .question5(questions.getQuestion5())
                 .enterprise(enterprise)
                 .build();
 

--- a/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
@@ -1,0 +1,20 @@
+package com.prototyne.Enterprise.converter;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.domain.Product;
+
+public class ProductConverter {
+    // 시제품 목록 조회 응답 형식으로
+    public static ProductDTO.ProductResponse toProductResponse(Product product) {
+        return ProductDTO.ProductResponse.builder()
+                .productId(product.getId())
+                .thumbnailUrl(product.getThumbnailUrl())
+                .productName(product.getName())
+                .reqTickets(product.getReqTickets())
+                .createdDate(product.getCreatedAt().toLocalDate())
+                .category(product.getCategory())
+                // 진행 중인 체험이 없다면 0
+                .eventCount(product.getEventList() != null ? product.getEventList().size() : 0)
+                .build();
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
@@ -3,6 +3,10 @@ package com.prototyne.Enterprise.converter;
 import com.prototyne.Enterprise.web.dto.ProductDTO;
 import com.prototyne.domain.Enterprise;
 import com.prototyne.domain.Product;
+import com.prototyne.domain.ProductImage;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ProductConverter {
     // 시제품 목록 조회 응답 형식으로
@@ -21,9 +25,10 @@ public class ProductConverter {
 
     // 시제품 엔티티 형식으로
     public static Product toProduct(ProductDTO.CreateProductRequest request,
-                                    Enterprise enterprise) {
-
-        return Product.builder()
+                                    Enterprise enterprise,
+                                    List<String> imageUrls) {
+        // Product 생성
+        Product newProduct = Product.builder()
                 .name(request.getProductName())
                 .contents(request.getContents())
                 .reqTickets(request.getReqTickets())
@@ -36,5 +41,27 @@ public class ProductConverter {
                 .question5(request.getQuestions().getQuestion5())
                 .enterprise(enterprise)
                 .build();
+
+        // 이미지 업로드한 경우에만 ProductImage 생성
+        if (imageUrls != null && !imageUrls.isEmpty()) {
+            // imageList 초기화 후, imageUrlsList와 연결
+            if (newProduct.getProductImageList() == null) {
+                newProduct.setProductImageList(new ArrayList<>());
+            }
+
+            List<ProductImage> productImages = imageUrls.stream()
+                    .map(url -> ProductImage.builder()
+                            .imageUrl(url)
+                            .product(newProduct)
+                            .build())
+                    .toList();
+
+            newProduct.getProductImageList().addAll(productImages);
+
+            // 첫번째 이미지로 썸네일 설정
+            newProduct.setThumbnailUrl(productImages.get(0).getImageUrl());
+        }
+
+        return newProduct;
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
@@ -1,6 +1,7 @@
 package com.prototyne.Enterprise.converter;
 
 import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.domain.Enterprise;
 import com.prototyne.domain.Product;
 
 public class ProductConverter {
@@ -15,6 +16,25 @@ public class ProductConverter {
                 .category(product.getCategory())
                 // 진행 중인 체험이 없다면 0
                 .eventCount(product.getEventList() != null ? product.getEventList().size() : 0)
+                .build();
+    }
+
+    // 시제품 엔티티 형식으로
+    public static Product toProduct(ProductDTO.CreateProductRequest request,
+                                    Enterprise enterprise) {
+
+        return Product.builder()
+                .name(request.getProductName())
+                .contents(request.getContents())
+                .reqTickets(request.getReqTickets())
+                .notes(request.getNotes())
+                .category(request.getCategory())
+                .question1(request.getQuestions().getQuestion1())
+                .question2(request.getQuestions().getQuestion2())
+                .question3(request.getQuestions().getQuestion3())
+                .question4(request.getQuestions().getQuestion4())
+                .question5(request.getQuestions().getQuestion5())
+                .enterprise(enterprise)
                 .build();
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
@@ -9,6 +9,8 @@ public interface EventService {
     List<EventDTO.EventResponse> getEvents(String accessToken);
 
     // 기업 id가 가진 시제품에 체험 등록 (토큰 인증 필수) - id 반환
-    Long createEvent(String accessToken, Long productId, EventDTO.createEventRequest request);
+    Long createEvent(String accessToken, Long productId, EventDTO.EventDate request);
 
+    // 체험 정보 상세 조회
+    EventDTO.EventInfo getEventInfo(String accessToken, Long eventId);
 }

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
@@ -1,0 +1,10 @@
+package com.prototyne.Enterprise.service.EventService;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+
+import java.util.List;
+
+public interface EventService {
+    // 기업 id에 따른 체험 목록 조회 (토큰 인증 필수)
+    List<ProductDTO.EventResponse> getEvents(String accessToken);
+}

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
@@ -1,10 +1,14 @@
 package com.prototyne.Enterprise.service.EventService;
 
-import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Enterprise.web.dto.EventDTO;
 
 import java.util.List;
 
 public interface EventService {
     // 기업 id에 따른 체험 목록 조회 (토큰 인증 필수)
-    List<ProductDTO.EventResponse> getEvents(String accessToken);
+    List<EventDTO.EventResponse> getEvents(String accessToken);
+
+    // 기업 id가 가진 시제품에 체험 등록 (토큰 인증 필수) - id 반환
+    Long createEvent(String accessToken, Long productId, EventDTO.createEventRequest request);
+
 }

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
@@ -1,0 +1,39 @@
+package com.prototyne.Enterprise.service.EventService;
+
+import com.prototyne.Enterprise.converter.EventConverter;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.domain.Event;
+import com.prototyne.repository.EventRepository;
+import com.prototyne.repository.ProductRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service("enterpriseEventServiceImpl")
+@AllArgsConstructor
+public class EventServiceImpl implements EventService {
+
+    private final JwtManager jwtManager;
+    private final ProductRepository productRepository;
+    private final EventRepository eventRepository;
+
+    // 체험 목록 조회
+    @Override
+    public List<ProductDTO.EventResponse> getEvents(String accessToken) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+        LocalDate now = LocalDate.now(); // 현재 날짜
+
+        // 1. 기업 ID로 모든 이벤트 조회
+        List<Event> events = eventRepository.findByEnterpriseId(enterpriseId);
+
+        /// 2. DTO 변환
+        return events.stream()
+                .map(event -> EventConverter.toEventResponse(event, event.getProduct(), now))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
@@ -42,7 +42,7 @@ public class EventServiceImpl implements EventService {
 
     // 체험 등록
     @Override
-    public Long createEvent(String accessToken, Long productId, EventDTO.createEventRequest request) {
+    public Long createEvent(String accessToken, Long productId, EventDTO.EventDate request) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);
 
         // 시제품 객체 조회
@@ -58,5 +58,24 @@ public class EventServiceImpl implements EventService {
         Event event = eventRepository.save(newEvent);
 
         return event.getId();
+    }
+
+    // 체험 상세 조회
+    @Override
+    public EventDTO.EventInfo getEventInfo(String accessToken, Long eventId) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+
+        // 체험 객체 조회
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.EVENT_ERROR_ID));
+
+        // 이벤트로부터 제품 객체 가져오기
+        Product product = event.getProduct();
+
+        // 해당 시제품을 기업이 가졌는지 확인
+        if (!product.getEnterprise().getId().equals(enterpriseId))
+            throw new TempHandler(ErrorStatus.ENTERPRISE_ERROR_PRODUCT);
+
+        return EventConverter.toEventInfo(product, event);
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
@@ -1,10 +1,14 @@
 package com.prototyne.Enterprise.service.ProductService;
 
 import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.domain.Product;
 
 import java.util.List;
 
 public interface ProductService {
     // 기업 id에 따른 시제품 목록 조회 (토큰 인증 필수)
     List<ProductDTO.ProductResponse> getProducts(String accessToken);
+
+    // 기업 id에 따른 시제품 등록 (토큰 인증 필수)
+    Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest);
 }

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
@@ -2,6 +2,7 @@ package com.prototyne.Enterprise.service.ProductService;
 
 import com.prototyne.Enterprise.web.dto.ProductDTO;
 import com.prototyne.domain.Product;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -10,7 +11,7 @@ public interface ProductService {
     List<ProductDTO.ProductResponse> getProducts(String accessToken);
 
     // 기업 id로부터 시제품 등록 (토큰 인증 필수)
-    Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest);
+    Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest, List<MultipartFile> images);
 
     // 기업 id가 가진 시제품 삭제
     void deleteProduct(String accessToken, Long productId);

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
@@ -10,8 +10,8 @@ public interface ProductService {
     // 기업 id에 따른 시제품 목록 조회 (토큰 인증 필수)
     List<ProductDTO.ProductResponse> getProducts(String accessToken);
 
-    // 기업 id로부터 시제품 등록 (토큰 인증 필수)
-    Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest, List<MultipartFile> images);
+    // 기업 id로부터 시제품 등록 (토큰 인증 필수) - id 반환
+    Long createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest, List<MultipartFile> images);
 
     // 기업 id가 가진 시제품 삭제
     void deleteProduct(String accessToken, Long productId);

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
@@ -9,6 +9,9 @@ public interface ProductService {
     // 기업 id에 따른 시제품 목록 조회 (토큰 인증 필수)
     List<ProductDTO.ProductResponse> getProducts(String accessToken);
 
-    // 기업 id에 따른 시제품 등록 (토큰 인증 필수)
+    // 기업 id로부터 시제품 등록 (토큰 인증 필수)
     Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest);
+
+    // 기업 id가 가진 시제품 삭제
+    void deleteProduct(String accessToken, Long productId);
 }

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
@@ -1,0 +1,10 @@
+package com.prototyne.Enterprise.service.ProductService;
+
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+
+import java.util.List;
+
+public interface ProductService {
+    // 기업 id에 따른 시제품 목록 조회 (토큰 인증 필수)
+    List<ProductDTO.ProductResponse> getProducts(String accessToken);
+}

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -40,7 +40,7 @@ public class ProductServiceImpl implements ProductService {
 
     // 세제품 등록
     @Override
-    public Product createProduct(String accessToken,
+    public Long createProduct(String accessToken,
                                  ProductDTO.CreateProductRequest productRequest,
                                  List<MultipartFile> images) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);
@@ -60,7 +60,9 @@ public class ProductServiceImpl implements ProductService {
         List<String> imageUrls = s3Manager.uploadFile("product", images);
         Product newProduct = ProductConverter.toProduct(productRequest, enterprise, imageUrls);
 
-        return productRepository.save(newProduct);
+        // 시제품 저장 및 id 반환
+        Product product = productRepository.save(newProduct);
+        return product.getId();
     }
 
     // 시제품 삭제

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -27,9 +27,6 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public List<ProductDTO.ProductResponse> getProducts(String accessToken) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);
-        // 기업 객체 조회
-        Enterprise enterprise = enterpriseRepository.findById(enterpriseId)
-                .orElseThrow(() -> new TempHandler(ErrorStatus.ENTERPRISE_ERROR_ID));
 
         List<Product> products = productRepository.findByEnterpriseId(enterpriseId);
         return  products.stream()
@@ -41,11 +38,37 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);
-        // 기업 객체 조회
+
+        // 기업 조회
         Enterprise enterprise = enterpriseRepository.findById(enterpriseId)
                 .orElseThrow(() -> new TempHandler(ErrorStatus.ENTERPRISE_ERROR_ID));
 
         Product newProduct = ProductConverter.toProduct(productRequest, enterprise);
         return productRepository.save(newProduct);
     }
+
+    // 시제품 삭제
+    @Override
+    public void deleteProduct(String accessToken, Long productId) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+
+        // 시제품 객체 조회
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.PRODUCT_ERROR_ID));
+
+        // 해당 시제품을 기업이 가졌는지 확인
+        if (!product.getEnterprise().getId().equals(enterpriseId)) {
+            throw new TempHandler(ErrorStatus.ENTERPRISE_ERROR_PRODUCT);
+        }
+
+        // 해당 시제품에 연결된 이벤트가 있는지 확인
+        if (!product.getEventList().isEmpty()) {
+            throw new TempHandler(ErrorStatus.PRODUCT_ERROR_EVENTLIST);
+        }
+
+        // 제품 삭제
+        productRepository.delete(product);
+    }
+
+
 }

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -5,13 +5,16 @@ import com.prototyne.Enterprise.web.dto.ProductDTO;
 import com.prototyne.Users.service.LoginService.JwtManager;
 import com.prototyne.apiPayload.code.status.ErrorStatus;
 import com.prototyne.apiPayload.exception.handler.TempHandler;
+import com.prototyne.aws.s3.AmazonS3Manager;
 import com.prototyne.domain.Enterprise;
 import com.prototyne.domain.Product;
 import com.prototyne.repository.EnterpriseRepository;
 import com.prototyne.repository.ProductRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,6 +25,7 @@ public class ProductServiceImpl implements ProductService {
     private final JwtManager jwtManager;
     private final ProductRepository productRepository;
     private final EnterpriseRepository enterpriseRepository;
+    private final AmazonS3Manager s3Manager;
 
     // 시제품 목록 조회
     @Override
@@ -36,14 +40,26 @@ public class ProductServiceImpl implements ProductService {
 
     // 세제품 등록
     @Override
-    public Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest) {
+    public Product createProduct(String accessToken,
+                                 ProductDTO.CreateProductRequest productRequest,
+                                 List<MultipartFile> images) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);
 
         // 기업 조회
         Enterprise enterprise = enterpriseRepository.findById(enterpriseId)
                 .orElseThrow(() -> new TempHandler(ErrorStatus.ENTERPRISE_ERROR_ID));
 
-        Product newProduct = ProductConverter.toProduct(productRequest, enterprise);
+        // null일 경우 빈 리스트로 대체
+        if (images == null) images = new ArrayList<>();
+
+        // 이미지 3장 이상일 경우 에러
+        if (images.size() > 3)
+            throw new TempHandler(ErrorStatus.IMAGE_LIMIT_EXCEEDED);  // 새로운 에러 코드 정의 필요
+
+        // S3에 이미지 업로드
+        List<String> imageUrls = s3Manager.uploadFile("product", images);
+        Product newProduct = ProductConverter.toProduct(productRequest, enterprise, imageUrls);
+
         return productRepository.save(newProduct);
     }
 
@@ -57,18 +73,14 @@ public class ProductServiceImpl implements ProductService {
                 .orElseThrow(() -> new TempHandler(ErrorStatus.PRODUCT_ERROR_ID));
 
         // 해당 시제품을 기업이 가졌는지 확인
-        if (!product.getEnterprise().getId().equals(enterpriseId)) {
+        if (!product.getEnterprise().getId().equals(enterpriseId))
             throw new TempHandler(ErrorStatus.ENTERPRISE_ERROR_PRODUCT);
-        }
 
         // 해당 시제품에 연결된 이벤트가 있는지 확인
-        if (!product.getEventList().isEmpty()) {
+        if (!product.getEventList().isEmpty())
             throw new TempHandler(ErrorStatus.PRODUCT_ERROR_EVENTLIST);
-        }
 
         // 제품 삭제
         productRepository.delete(product);
     }
-
-
 }

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -1,0 +1,29 @@
+package com.prototyne.Enterprise.service.ProductService;
+
+import com.prototyne.Enterprise.converter.ProductConverter;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.domain.Product;
+import com.prototyne.repository.ProductRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final JwtManager jwtManager;
+    private final ProductRepository productRepository;
+
+    @Override
+    public List<ProductDTO.ProductResponse> getProducts(String accessToken) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+        List<Product> products = productRepository.findByEnterpriseId(enterpriseId);
+        return  products.stream()
+                .map(ProductConverter::toProductResponse) // 컨버터 메소드 호출
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -3,7 +3,11 @@ package com.prototyne.Enterprise.service.ProductService;
 import com.prototyne.Enterprise.converter.ProductConverter;
 import com.prototyne.Enterprise.web.dto.ProductDTO;
 import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.apiPayload.code.status.ErrorStatus;
+import com.prototyne.apiPayload.exception.handler.TempHandler;
+import com.prototyne.domain.Enterprise;
 import com.prototyne.domain.Product;
+import com.prototyne.repository.EnterpriseRepository;
 import com.prototyne.repository.ProductRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,14 +21,31 @@ public class ProductServiceImpl implements ProductService {
 
     private final JwtManager jwtManager;
     private final ProductRepository productRepository;
+    private final EnterpriseRepository enterpriseRepository;
 
     // 시제품 목록 조회
     @Override
     public List<ProductDTO.ProductResponse> getProducts(String accessToken) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);
+        // 기업 객체 조회
+        Enterprise enterprise = enterpriseRepository.findById(enterpriseId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.ENTERPRISE_ERROR_ID));
+
         List<Product> products = productRepository.findByEnterpriseId(enterpriseId);
         return  products.stream()
                 .map(ProductConverter::toProductResponse) // 컨버터 메소드 호출
                 .collect(Collectors.toList());
+    }
+
+    // 세제품 등록
+    @Override
+    public Product createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+        // 기업 객체 조회
+        Enterprise enterprise = enterpriseRepository.findById(enterpriseId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.ENTERPRISE_ERROR_ID));
+
+        Product newProduct = ProductConverter.toProduct(productRequest, enterprise);
+        return productRepository.save(newProduct);
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductServiceImpl.java
@@ -18,6 +18,7 @@ public class ProductServiceImpl implements ProductService {
     private final JwtManager jwtManager;
     private final ProductRepository productRepository;
 
+    // 시제품 목록 조회
     @Override
     public List<ProductDTO.ProductResponse> getProducts(String accessToken) {
         Long enterpriseId = jwtManager.validateJwt(accessToken);

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
@@ -50,7 +50,7 @@ public class EventController {
             security = {@SecurityRequirement(name = "session-token")} )
     public ApiResponse<Long> createEvent(HttpServletRequest token,
                                          @PathVariable Long productId,
-                                         @RequestBody @Valid EventDTO.createEventRequest eventRequest) {
+                                         @Valid @RequestBody EventDTO.createEventRequest eventRequest) {
         String oauthToken = jwtManager.getToken(token);
         Long eventId = eventService.createEvent(oauthToken, productId, eventRequest);
         return ApiResponse.onSuccess(eventId);

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
@@ -1,18 +1,17 @@
 package com.prototyne.Enterprise.web.controller;
 
 import com.prototyne.Enterprise.service.EventService.EventService;
-import com.prototyne.Enterprise.service.ProductService.ProductService;
-import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Enterprise.web.dto.EventDTO;
 import com.prototyne.Users.service.LoginService.JwtManager;
 import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.domain.Event;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -37,10 +36,26 @@ public class EventController {
         4: 후기 작성 기간       | 후기 작성 종료      | feedback_end
         5: 종료                 | 종료일             | end_date
     """, security = {@SecurityRequirement(name = "session-token")})
-    public ApiResponse<List<ProductDTO.EventResponse>> getEventsList(HttpServletRequest token) {
+    public ApiResponse<List<EventDTO.EventResponse>> getEventsList(HttpServletRequest token) {
         String oauthToken = jwtManager.getToken(token);
-        List<ProductDTO.EventResponse> eventList = eventService.getEvents(oauthToken);
+        List<EventDTO.EventResponse> eventList = eventService.getEvents(oauthToken);
         return ApiResponse.onSuccess(eventList);
     }
 
+    // 체험 정보 조회
+
+    // 시제품에 체험 등록
+    @PostMapping("/products/{productId}/event")
+    @Operation(summary = "체험 등록 API - 인증 필수",
+            security = {@SecurityRequirement(name = "session-token")} )
+    public ApiResponse<Long> createEvent(HttpServletRequest token,
+                                         @PathVariable Long productId,
+                                         @RequestBody @Valid EventDTO.createEventRequest eventRequest) {
+        String oauthToken = jwtManager.getToken(token);
+        Long eventId = eventService.createEvent(oauthToken, productId, eventRequest);
+        return ApiResponse.onSuccess(eventId);
+    }
+
+
+    // 체험 삭제
 }

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
@@ -1,0 +1,46 @@
+package com.prototyne.Enterprise.web.controller;
+
+import com.prototyne.Enterprise.service.EventService.EventService;
+import com.prototyne.Enterprise.service.ProductService.ProductService;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/enterprise")
+@Tag(name = "${swagger.tag.enterprise-event}")
+public class EventController {
+
+    private final JwtManager jwtManager;
+    private final EventService eventService;
+
+    // 체험 목록 조회
+    @GetMapping("/events")
+    @Operation(summary = "체험 목록 조회 API - 인증 필수" ,
+            description = "시제품 체험 목록 > 체험 목록" +"""
+        --- stageAndDate는 stage(단계)와 stageDate(그에 따른 날짜)로 구성
+
+        1: 시작 전              | 시작일             | event_start
+        2: 신청자 모집 기간     | 신청자 모집 종료    | event_end
+        3: 당첨자 발표 기간     | 당첨자 발표 종료    | release_end
+        4: 후기 작성 기간       | 후기 작성 종료      | feedback_end
+        5: 종료                 | 종료일             | end_date
+    """, security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<List<ProductDTO.EventResponse>> getEventsList(HttpServletRequest token) {
+        String oauthToken = jwtManager.getToken(token);
+        List<ProductDTO.EventResponse> eventList = eventService.getEvents(oauthToken);
+        return ApiResponse.onSuccess(eventList);
+    }
+
+}

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
@@ -42,20 +42,42 @@ public class EventController {
         return ApiResponse.onSuccess(eventList);
     }
 
-    // 체험 정보 조회
-
     // 시제품에 체험 등록
     @PostMapping("/products/{productId}/event")
     @Operation(summary = "체험 등록 API - 인증 필수",
+            description = """
+                    시제품에 체험 등록(추가) \n
+                    productId 입력 \n
+                    요청 성공 시, 체험 아이디(event_id) 반환""",
             security = {@SecurityRequirement(name = "session-token")} )
     public ApiResponse<Long> createEvent(HttpServletRequest token,
                                          @PathVariable Long productId,
-                                         @Valid @RequestBody EventDTO.createEventRequest eventRequest) {
+                                         @Valid @RequestBody EventDTO.EventDate eventRequest) {
         String oauthToken = jwtManager.getToken(token);
         Long eventId = eventService.createEvent(oauthToken, productId, eventRequest);
         return ApiResponse.onSuccess(eventId);
     }
 
+    // 체험 정보 조회
+    @GetMapping("/events/{eventId}")
+    @Operation(summary = "체험 정보 조회 API - 인증 필수",
+            description = """
+                    체험 상세 조회 \n 
+                    eventId 입력""",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<EventDTO.EventInfo> getEvent(HttpServletRequest token, @PathVariable Long eventId) {
+        String oauthToken = jwtManager.getToken(token);
+        EventDTO.EventInfo event = eventService.getEventInfo(oauthToken, eventId);
+        return ApiResponse.onSuccess(event);
+    }
 
     // 체험 삭제
+    @DeleteMapping("/events/{eventId}")
+    @Operation(summary = "체험 삭제 API - 인증 필수",
+            description = "구현 중",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<String> deleteEvent(HttpServletRequest token, @PathVariable Long eventId) {
+        String oauthToken = jwtManager.getToken(token);
+        return ApiResponse.onSuccess("삭제 성공");
+    }
 }

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -1,0 +1,37 @@
+package com.prototyne.Enterprise.web.controller;
+
+import com.prototyne.Enterprise.service.ProductService.ProductService;
+import com.prototyne.Enterprise.web.dto.ProductDTO;
+import com.prototyne.Users.service.LoginService.JwtManager;
+import com.prototyne.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController("enterpriseProductController")
+@RequiredArgsConstructor
+@RequestMapping("/enterprise")
+@Tag(name = "${swagger.tag.enterprise-product}")
+public class ProductController {
+
+    private final JwtManager jwtManager;
+    private final ProductService productService;
+
+    // 시제품 목록 조회
+    @GetMapping("/products")
+    @Operation(summary = "시제품 목록 조회 API - 인증 필수" ,
+            description = "시제품 체험 목록 > 시제품 목록 \n ** 기업 로그인 상태 필수 **",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<List<ProductDTO.ProductResponse>> getEventsList(HttpServletRequest token) {
+        String oauthToken = jwtManager.getToken(token);
+        List<ProductDTO.ProductResponse> productList =  productService.getProducts(oauthToken);
+        return ApiResponse.onSuccess(productList);
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -58,11 +58,9 @@ public class ProductController {
     public ApiResponse<Long> createProduct(HttpServletRequest token,
                                     @Valid @RequestPart("productRequest") ProductDTO.CreateProductRequest productRequest,
                                            @RequestPart(value = "imageFiles", required = false) List<MultipartFile> images){
-
-
         String oauthToken = jwtManager.getToken(token);
-        Product newProduct = productService.createProduct(oauthToken, productRequest, images);
-        return ApiResponse.onSuccess(newProduct.getId());
+        Long productId = productService.createProduct(oauthToken, productRequest, images);
+        return ApiResponse.onSuccess(productId);
     }
 
     // 시제품 삭제

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -38,12 +38,36 @@ public class ProductController {
     // 시제품 등록
     @PostMapping("/products")
     @Operation(summary = "시제품 등록 API - 인증 필수",
-            description = "시제품 등록(추가)",
+            description = "시제품 등록(추가)" + """
+                    
+                    1. 시제품 명 (productName) - 공백 시 에러
+                    2. 설명 (contents - 공백 시 에러
+                    3. 티켓 갯수 (reqTickets)
+                    4. 추가 안내사항 (notes) - 공백 시 에러
+                    5. 카테고리 (category)
+                    6. 제품 사진 (최대 3장) - 아직 구현 x
+                    7. 질문 목록 (1~5)
+                    
+                    요청 성공 시, 시제품 아이디(product_id) 반환""",
             security = {@SecurityRequirement(name = "session-token")})
-    public ApiResponse<Long> create(HttpServletRequest token,
+    public ApiResponse<Long> createProduct(HttpServletRequest token,
                                     @Valid @RequestBody ProductDTO.CreateProductRequest productRequest){
         String oauthToken = jwtManager.getToken(token);
         Product newProduct = productService.createProduct(oauthToken, productRequest);
         return ApiResponse.onSuccess(newProduct.getId());
+    }
+
+    // 시제품 삭제
+    @DeleteMapping("/products/{productId}")
+    @Operation(summary = "시제품 등록 API - 인증 필수",
+            description = """
+                    시제품 삭제 \n
+                    productId 입력 \n
+                    시제품(product)에 연결된 체험(event)이 없어야 삭제 가능""",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<String> deleteProduct(HttpServletRequest token, @PathVariable Long productId) {
+        String oauthToken = jwtManager.getToken(token);
+        productService.deleteProduct(oauthToken, productId);
+        return ApiResponse.onSuccess("삭제 성공");
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -6,12 +6,17 @@ import com.prototyne.Users.service.LoginService.JwtManager;
 import com.prototyne.apiPayload.ApiResponse;
 import com.prototyne.domain.Product;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -36,7 +41,7 @@ public class ProductController {
     }
 
     // 시제품 등록
-    @PostMapping("/products")
+    @PostMapping(value = "/products", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "시제품 등록 API - 인증 필수",
             description = "시제품 등록(추가)" + """
                     
@@ -45,15 +50,18 @@ public class ProductController {
                     3. 티켓 갯수 (reqTickets)
                     4. 추가 안내사항 (notes) - 공백 시 에러
                     5. 카테고리 (category)
-                    6. 제품 사진 (최대 3장) - 아직 구현 x
-                    7. 질문 목록 (1~5)
+                    6. 질문 목록 (1~5)
+                    7. imageFiles : 제품 사진 (최대 3장)
                     
                     요청 성공 시, 시제품 아이디(product_id) 반환""",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<Long> createProduct(HttpServletRequest token,
-                                    @Valid @RequestBody ProductDTO.CreateProductRequest productRequest){
+                                    @Valid @RequestPart("productRequest") ProductDTO.CreateProductRequest productRequest,
+                                           @RequestPart(value = "imageFiles", required = false) List<MultipartFile> images){
+
+
         String oauthToken = jwtManager.getToken(token);
-        Product newProduct = productService.createProduct(oauthToken, productRequest);
+        Product newProduct = productService.createProduct(oauthToken, productRequest, images);
         return ApiResponse.onSuccess(newProduct.getId());
     }
 

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -27,11 +27,12 @@ public class ProductController {
     // 시제품 목록 조회
     @GetMapping("/products")
     @Operation(summary = "시제품 목록 조회 API - 인증 필수" ,
-            description = "시제품 체험 목록 > 시제품 목록 \n ** 기업 로그인 상태 필수 **",
+            description = "시제품 체험 목록 > 시제품 목록",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<List<ProductDTO.ProductResponse>> getEventsList(HttpServletRequest token) {
         String oauthToken = jwtManager.getToken(token);
         List<ProductDTO.ProductResponse> productList =  productService.getProducts(oauthToken);
         return ApiResponse.onSuccess(productList);
     }
+
 }

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -4,14 +4,14 @@ import com.prototyne.Enterprise.service.ProductService.ProductService;
 import com.prototyne.Enterprise.web.dto.ProductDTO;
 import com.prototyne.Users.service.LoginService.JwtManager;
 import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.domain.Product;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,13 +26,24 @@ public class ProductController {
 
     // 시제품 목록 조회
     @GetMapping("/products")
-    @Operation(summary = "시제품 목록 조회 API - 인증 필수" ,
+    @Operation(summary = "시제품 목록 조회 API - 인증 필수",
             description = "시제품 체험 목록 > 시제품 목록",
             security = {@SecurityRequirement(name = "session-token")})
-    public ApiResponse<List<ProductDTO.ProductResponse>> getEventsList(HttpServletRequest token) {
+    public ApiResponse<List<ProductDTO.ProductResponse>> getProductsList(HttpServletRequest token) {
         String oauthToken = jwtManager.getToken(token);
         List<ProductDTO.ProductResponse> productList =  productService.getProducts(oauthToken);
         return ApiResponse.onSuccess(productList);
     }
 
+    // 시제품 등록
+    @PostMapping("/products")
+    @Operation(summary = "시제품 등록 API - 인증 필수",
+            description = "시제품 등록(추가)",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<Long> create(HttpServletRequest token,
+                                    @Valid @RequestBody ProductDTO.CreateProductRequest productRequest){
+        String oauthToken = jwtManager.getToken(token);
+        Product newProduct = productService.createProduct(oauthToken, productRequest);
+        return ApiResponse.onSuccess(newProduct.getId());
+    }
 }

--- a/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
@@ -6,13 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class EventDTO {
 
     // 체험 등록 요청 형식
     @Builder
     @Getter
-    public static class createEventRequest {
+    public static class EventDate {
         @NotNull(message = "eventStart가 공백입니다.")
         private final LocalDate eventStart;     // 체험 시작
         @NotNull(message = "eventEnd가 공백입니다.")
@@ -45,5 +46,16 @@ public class EventDTO {
     public static class StageAndDate {
         private final Integer stage;       // 이벤트 단계
         private final LocalDate stageDate;   // 단계에 따른 날짜
+    }
+
+    // 체험 정보 조회
+    @Builder
+    @Getter
+    public static class EventInfo {
+        private final Long productId;
+        private final Long eventId;
+        private final List<String> productImages;
+        private final ProductDTO.ProductInfo productInfo;
+        private final EventDate dates;
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
@@ -1,0 +1,49 @@
+package com.prototyne.Enterprise.web.dto;
+
+import com.prototyne.domain.enums.ProductCategory;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class EventDTO {
+
+    // 체험 등록 요청 형식
+    @Builder
+    @Getter
+    public static class createEventRequest {
+        @NotBlank(message = "eventStart가 공백입니다.")
+        private final LocalDate eventStart;     // 체험 시작
+        @NotBlank(message = "eventEnd가 공백입니다.")
+        private final LocalDate eventEnd;       // 체험 마감
+        @NotBlank(message = "releaseStart가 공백입니다.")
+        private final LocalDate releaseStart;   // 당첨자 시작
+        @NotBlank(message = "releaseEnd가 공백입니다.")
+        private final LocalDate releaseEnd;     // 당첨자 종료
+        @NotBlank(message = "feedbackStart가 공백입니다.")
+        private final LocalDate feedbackStart;  // 피드백 시작
+        @NotBlank(message = "feedbackEnd가 공백입니다.")
+        private final LocalDate feedbackEnd;    // 피드백 종료
+    }
+
+    // 체험 목록 조회 응답 형식
+    @Builder
+    @Getter
+    public static class EventResponse {
+        private final Long eventId;           // 체험(이벤트) 아이디
+        private final String thumbnailUrl;    // 시제품 썸네일
+        private final String productName;     // 시제품 명
+        private final StageAndDate stageAndDate;  // 체험(이벤트) 단계와 그에 따른 날짜
+        private final LocalDate createdDate;  // 체험(이벤트) 등록일
+        private final ProductCategory category;   // 시제품 카테고리
+    }
+
+    // 체험(이벤트) 단계 및 날짜
+    @Getter
+    @Builder
+    public static class StageAndDate {
+        private final Integer stage;       // 이벤트 단계
+        private final LocalDate stageDate;   // 단계에 따른 날짜
+    }
+}

--- a/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
@@ -1,7 +1,7 @@
 package com.prototyne.Enterprise.web.dto;
 
 import com.prototyne.domain.enums.ProductCategory;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,17 +13,17 @@ public class EventDTO {
     @Builder
     @Getter
     public static class createEventRequest {
-        @NotBlank(message = "eventStart가 공백입니다.")
+        @NotNull(message = "eventStart가 공백입니다.")
         private final LocalDate eventStart;     // 체험 시작
-        @NotBlank(message = "eventEnd가 공백입니다.")
+        @NotNull(message = "eventEnd가 공백입니다.")
         private final LocalDate eventEnd;       // 체험 마감
-        @NotBlank(message = "releaseStart가 공백입니다.")
+        @NotNull(message = "releaseStart가 공백입니다.")
         private final LocalDate releaseStart;   // 당첨자 시작
-        @NotBlank(message = "releaseEnd가 공백입니다.")
+        @NotNull(message = "releaseEnd가 공백입니다.")
         private final LocalDate releaseEnd;     // 당첨자 종료
-        @NotBlank(message = "feedbackStart가 공백입니다.")
+        @NotNull(message = "feedbackStart가 공백입니다.")
         private final LocalDate feedbackStart;  // 피드백 시작
-        @NotBlank(message = "feedbackEnd가 공백입니다.")
+        @NotNull(message = "feedbackEnd가 공백입니다.")
         private final LocalDate feedbackEnd;    // 피드백 종료
     }
 

--- a/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
@@ -12,14 +12,32 @@ public class ProductDTO {
     @Builder
     @Getter
     public static class ProductResponse {
-        private Long productId;         // 시제품 아이디
-        private String thumbnailUrl;    // 시제품 썸네일
-        private String productName;     // 시제품 명
-        private Integer reqTickets;     // 시제품 필요 티켓 수
-        private LocalDate createdDate;  // 시제품 등록일
-        private ProductCategory category;   // 시제품 카테고리
-        private Integer eventCount;     // 진행 중인 체험
+        private final Long productId;         // 시제품 아이디
+        private final String thumbnailUrl;    // 시제품 썸네일
+        private final String productName;     // 시제품 명
+        private final Integer reqTickets;     // 시제품 필요 티켓 수
+        private final LocalDate createdDate;  // 시제품 등록일
+        private final ProductCategory category;   // 시제품 카테고리
+        private final Integer eventCount;     // 진행 중인 체험
 //        private LocalDate date;       // 출시 예정일
     }
 
+    // 체험 목록 조회 응답 형식
+    @Builder
+    @Getter
+    public static class EventResponse {
+        private final Long eventId;           // 체험(이벤트) 아이디
+        private final String thumbnailUrl;    // 시제품 썸네일
+        private final String productName;     // 시제품 명
+        private final StageAndDate stageAndDate;  // 체험(이벤트) 단계와 그에 따른 날짜
+        private final LocalDate createdDate;  // 체험(이벤트) 등록일
+        private final ProductCategory category;   // 시제품 카테고리
+    }
+
+    @Getter
+    @Builder
+    public static class StageAndDate {
+        private final Integer stage;       // 이벤트 단계
+        private final LocalDate stageDate;   // 단계에 따른 날짜
+    }
 }

--- a/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
@@ -12,7 +12,15 @@ public class ProductDTO {
     // 시제품 등록 요청 형식
     @Builder
     @Getter
-    public static class CreateProductRequest{
+    public static class CreateProductRequest {
+        private ProductInfo productInfo;
+        private Questions questions;        // 질문 목록
+    }
+
+    // 시제품 정보
+    @Builder
+    @Getter
+    public static class ProductInfo {
         @NotBlank(message = "시제품 명이 공백입니다.")
         private final String productName;   // 시제품 명
 
@@ -24,13 +32,12 @@ public class ProductDTO {
         @NotBlank(message = "시제품 추가 안내사항이 공백입니다.")
         private String notes;               // 시제품 추가 안내사항
         private final ProductCategory category; // 시제품 카테고리
-        private Questions questions;        // 질문 목록
     }
 
     // 질문 목록
     @Builder
     @Getter
-    public static class Questions{
+    public static class Questions {
         private final String question1;
         private final String question2;
         private final String question3;

--- a/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
@@ -1,12 +1,42 @@
 package com.prototyne.Enterprise.web.dto;
 
 import com.prototyne.domain.enums.ProductCategory;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 public class ProductDTO {
+
+    // 시제품 등록 요청 형식
+    @Builder
+    @Getter
+    public static class CreateProductRequest{
+        @NotBlank(message = "시제품 명이 공백입니다.")
+        private final String productName;   // 시제품 명
+
+        @NotBlank(message = "시제품 설명이 공백입니다.")
+        private final String contents;      // 시제품 설명
+
+        private final Integer reqTickets;   // 시제품 필요 티켓 수
+
+        @NotBlank(message = "시제품 추가 안내사항이 공백입니다.")
+        private String notes;               // 시제품 추가 안내사항
+        private final ProductCategory category; // 시제품 카테고리
+        private Questions questions;        // 질문 목록
+    }
+
+    // 질문 목록
+    @Builder
+    @Getter
+    public static class Questions{
+        private final String question1;
+        private final String question2;
+        private final String question3;
+        private final String question4;
+        private final String question5;
+    }
 
     // 시제품 목록 조회 응답 형식
     @Builder
@@ -34,10 +64,13 @@ public class ProductDTO {
         private final ProductCategory category;   // 시제품 카테고리
     }
 
+    // 체험(이벤트) 단계 및 날짜
     @Getter
     @Builder
     public static class StageAndDate {
         private final Integer stage;       // 이벤트 단계
         private final LocalDate stageDate;   // 단계에 따른 날짜
     }
+
+    //
 }

--- a/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
@@ -1,0 +1,25 @@
+package com.prototyne.Enterprise.web.dto;
+
+import com.prototyne.domain.enums.ProductCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class ProductDTO {
+
+    // 시제품 목록 조회 응답 형식
+    @Builder
+    @Getter
+    public static class ProductResponse {
+        private Long productId;         // 시제품 아이디
+        private String thumbnailUrl;    // 시제품 썸네일
+        private String productName;     // 시제품 명
+        private Integer reqTickets;     // 시제품 필요 티켓 수
+        private LocalDate createdDate;  // 시제품 등록일
+        private ProductCategory category;   // 시제품 카테고리
+        private Integer eventCount;     // 진행 중인 체험
+//        private LocalDate date;       // 출시 예정일
+    }
+
+}

--- a/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/ProductDTO.java
@@ -51,26 +51,4 @@ public class ProductDTO {
         private final Integer eventCount;     // 진행 중인 체험
 //        private LocalDate date;       // 출시 예정일
     }
-
-    // 체험 목록 조회 응답 형식
-    @Builder
-    @Getter
-    public static class EventResponse {
-        private final Long eventId;           // 체험(이벤트) 아이디
-        private final String thumbnailUrl;    // 시제품 썸네일
-        private final String productName;     // 시제품 명
-        private final StageAndDate stageAndDate;  // 체험(이벤트) 단계와 그에 따른 날짜
-        private final LocalDate createdDate;  // 체험(이벤트) 등록일
-        private final ProductCategory category;   // 시제품 카테고리
-    }
-
-    // 체험(이벤트) 단계 및 날짜
-    @Getter
-    @Builder
-    public static class StageAndDate {
-        private final Integer stage;       // 이벤트 단계
-        private final LocalDate stageDate;   // 단계에 따른 날짜
-    }
-
-    //
 }

--- a/src/main/java/com/prototyne/Users/converter/MyProductConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/MyProductConverter.java
@@ -8,6 +8,7 @@ import com.prototyne.domain.enums.InvestmentStatus;
 import com.prototyne.Users.web.dto.MyProductDto;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
@@ -18,15 +19,15 @@ public class MyProductConverter {
     public MyProductDto.CommonDto toCommonDto(Investment investment) {
         Event event = investment.getEvent();
         Product product = event.getProduct();
-        LocalDateTime releaseStart = event.getReleaseStart();
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate releaseStart = event.getReleaseStart();
+        LocalDate now = LocalDate.now();
         String calculatedStatus;
 
         if(investment.getStatus()== InvestmentStatus.신청){
             if(releaseStart.isBefore(now)) {
                 calculatedStatus = "미당첨";
             } else {
-                long dDayToOngoing = (int) ChronoUnit.DAYS.between(now.toLocalDate(), releaseStart.toLocalDate());
+                long dDayToOngoing = (int) ChronoUnit.DAYS.between(now, releaseStart);
                 calculatedStatus = String.valueOf(dDayToOngoing);
             }
         } else {
@@ -46,11 +47,11 @@ public class MyProductConverter {
 
     public MyProductDto.AppliedDto toAppliedDto(Investment investment) {
         MyProductDto.CommonDto commonInfo = toCommonDto(investment);
-        LocalDateTime releaseStart = investment.getEvent().getReleaseStart();
+        LocalDate releaseStart = investment.getEvent().getReleaseStart();
         LocalDateTime now = LocalDateTime.now();
 
         // releaseStart - 현재 날짜
-        long dDayToOngoing = ChronoUnit.DAYS.between(now.toLocalDate(), releaseStart.toLocalDate());
+        long dDayToOngoing = ChronoUnit.DAYS.between(now.toLocalDate(), releaseStart);
 
         return MyProductDto.AppliedDto.builder()
                 .commonInfo(commonInfo)

--- a/src/main/java/com/prototyne/Users/converter/MyProductConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/MyProductConverter.java
@@ -73,16 +73,16 @@ public class MyProductConverter {
 
     public MyProductDto.ReviewedDto toReviewedDto(Investment investment) {
         MyProductDto.CommonDto commonInfo = toCommonDto(investment);
-        LocalDateTime judgeEnd = investment.getEvent().getJudgeEnd();
+//        LocalDateTime judgeEnd = investment.getEvent().getJudgeEnd();
         LocalDateTime now = LocalDateTime.now();
 
         // judgeEnd - 현재 날짜
-        long dDayToComplete = ChronoUnit.DAYS.between(now.toLocalDate(), judgeEnd.toLocalDate());
+//        long dDayToComplete = ChronoUnit.DAYS.between(now.toLocalDate(), judgeEnd.toLocalDate());
 
         return MyProductDto.ReviewedDto.builder()
                 .commonInfo(commonInfo)
-                .judgeEnd(judgeEnd)
-                .dDayToComplete((int) dDayToComplete)
+//                .judgeEnd(judgeEnd)
+//                .dDayToComplete((int) dDayToComplete)
                 .build();
     }
 

--- a/src/main/java/com/prototyne/Users/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/ProductConverter.java
@@ -84,9 +84,9 @@ public class ProductConverter {
                 .releaseEnd(event.getReleaseEnd())
                 .feedbackStart(event.getFeedbackStart())
                 .feedbackEnd(event.getFeedbackEnd())
-                .judgeStart(event.getJudgeStart())
-                .judgeEnd(event.getJudgeEnd())
-                .endDate(event.getEndDate())
+//                .judgeStart(event.getJudgeStart())
+//                .judgeEnd(event.getJudgeEnd())
+//                .endDate(event.getEndDate())
                 .build();
     }
 

--- a/src/main/java/com/prototyne/Users/service/AlarmService/AlarmServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/AlarmService/AlarmServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,7 +23,7 @@ public class AlarmServiceImpl implements AlarmService {
     @Override
     public List<AlarmDto> getAlarmList(String accessToken) {
         Long id = jwtManager.validateJwt(accessToken);
-        return alarmRespository.findByUserId(id).stream().sorted((o1, o2) -> o2.getStartReview().compareTo(o1.getStartReview())).filter(alarm -> !alarm.getStartReview().isAfter(LocalDateTime.now())).map(alarm -> AlarmDto.builder()
+        return alarmRespository.findByUserId(id).stream().sorted((o1, o2) -> o2.getStartReview().compareTo(o1.getStartReview())).filter(alarm -> !alarm.getStartReview().isAfter(LocalDate.now())).map(alarm -> AlarmDto.builder()
                         .title(alarm.getTitle())
                         .contents(alarm.getContents())
                         .thumbnailUrl(alarm.getThumbnailUrl())

--- a/src/main/java/com/prototyne/Users/service/ApplicationService/ApplicationServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/ApplicationService/ApplicationServiceImpl.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -89,7 +90,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                     .title("티켓 사용")
                     .contents("티켓 " + reqTickets + "개 사용 완료 - " + product.getName())
                     .thumbnailUrl(product.getThumbnailUrl())
-                    .StartReview(LocalDateTime.now())
+                    .StartReview(LocalDate.now())
                     .build());
 
             eventService.saveInvestment(investment);

--- a/src/main/java/com/prototyne/Users/service/MyProductService/MyProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/MyProductService/MyProductServiceImpl.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,7 +36,7 @@ public class MyProductServiceImpl implements MyProductService {
     @Override
     public List<MyProductDto.AppliedDto> getAppliedMyProduct(String accessToken) {
         Long userId = jwtManager.validateJwt(accessToken);
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
 
         return myProductRepository.findByUserId(userId).stream()
                 .filter(investment -> investment.getStatus() == InvestmentStatus.신청)

--- a/src/main/java/com/prototyne/Users/service/ProductService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/ProductService/EventServiceImpl.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Service
+@Service("usersEventServiceImpl")
 @RequiredArgsConstructor
 public class EventServiceImpl implements EventService {
 

--- a/src/main/java/com/prototyne/Users/service/ProductService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/ProductService/EventServiceImpl.java
@@ -17,7 +17,7 @@ import com.prototyne.Users.web.dto.ProductDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,7 +36,7 @@ public class EventServiceImpl implements EventService {
         // 유저 아이디 객체 가져옴
         Long userId = jwtManager.validateJwt(accessToken);
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
         List<ProductDTO.EventResponse> poluarList = getEvents(now, "popular")
                 .stream().limit(2)
                 .map(event -> {
@@ -72,7 +72,7 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public List<ProductDTO.EventResponse> getEventsByType(Long userId, String type) {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
 
         // 타입별 신청 진행 중인 시제품 이벤트만 가져옴
         List<Event> events = getEvents(now, type);
@@ -99,7 +99,7 @@ public class EventServiceImpl implements EventService {
 
 
         // 신청 진행 중인 시제품 이벤트만 가져옴
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
         List<Event> events = eventRepository.findAllByProductNameContaining(name).stream()
                 .filter(event -> now.isAfter(event.getEventStart()) && now.isBefore(event.getEventEnd()))
                 .collect(Collectors.toList());
@@ -165,7 +165,7 @@ public class EventServiceImpl implements EventService {
         // 카테고리 타입 변환 (String -> Enum)
         ProductCategory productCategory = changeToProductCategory(category);
         // 신청 진행 중인 시제품 이벤트만 가져옴
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
         List<Event> events = eventRepository.findByProductCategory(productCategory).stream()
                 .filter(event -> now.isAfter(event.getEventStart()) && now.isBefore(event.getEventEnd()))
                 .collect(Collectors.toList());
@@ -201,7 +201,7 @@ public class EventServiceImpl implements EventService {
     }
 
     // 타입별 이벤트 가져옴
-    private List<Event> getEvents(LocalDateTime now, String type) {
+    private List<Event> getEvents(LocalDate now, String type) {
         return switch (type) {
             case "popular" -> eventRepository.findAllActiveEventsByPopular(now);
             case "imminent" -> eventRepository.findAllEventsByImminent(now).stream()
@@ -224,7 +224,7 @@ public class EventServiceImpl implements EventService {
     }
 
     // 디데이 계산
-    private Integer calculateDDay(LocalDateTime now, LocalDateTime endDate) {
+    private Integer calculateDDay(LocalDate now, LocalDate endDate) {
         long daysBetween = java.time.Duration.between(now, endDate).toDays();
         return (int) daysBetween;
     }

--- a/src/main/java/com/prototyne/Users/service/TempService/TempCommandServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/TempService/TempCommandServiceImpl.java
@@ -8,6 +8,7 @@ import com.prototyne.apiPayload.code.status.ErrorStatus;
 import com.prototyne.apiPayload.exception.handler.TempHandler;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -24,6 +25,9 @@ public class TempCommandServiceImpl implements TempCommandService {
 
     // 이미지 업로드 및 URL 리스트 반환
     public TempResponse.TempUploadDTO uploadImages(String directory, List<MultipartFile> images) {
+        // null일 경우 빈 리스트로 대체
+        if (images == null) images = new ArrayList<>();
+
         // S3에 이미지 업로드
         List<String> imageUrls = s3Manager.uploadFile(directory, images);
 

--- a/src/main/java/com/prototyne/Users/service/TicketService/TicketServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/TicketService/TicketServiceImpl.java
@@ -85,7 +85,7 @@ public class TicketServiceImpl implements TicketService {
         // appliedNum
         Integer appliedNum = (int) myProductRepository.findByUserId(userId).stream()
                 .filter(investment -> investment.getStatus() == InvestmentStatus.신청)
-                .filter(investment -> investment.getEvent().getReleaseStart().isAfter(now))
+                .filter(investment -> investment.getEvent().getReleaseStart().atStartOfDay().isAfter(now))
                 .count();
 
         // selectedNum
@@ -136,7 +136,7 @@ public class TicketServiceImpl implements TicketService {
                 .user(user)
                 .title("티켓 구매")
                 .contents("티켓 " + ticketNumber + "개 구매 완료")
-                .StartReview(LocalDateTime.now())
+                .StartReview(LocalDate.now())
                 .build());
     }
 

--- a/src/main/java/com/prototyne/Users/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Users/web/controller/ProductController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RestController
+@RestController("usersProductController")
 @RequiredArgsConstructor
 @RequestMapping("/product")
 @Tag(name = "${swagger.tag.product}")

--- a/src/main/java/com/prototyne/Users/web/controller/TempRestController.java
+++ b/src/main/java/com/prototyne/Users/web/controller/TempRestController.java
@@ -24,8 +24,8 @@ public class TempRestController {
     private final JwtManager JwtManager;
 
     @PostMapping(value="/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<TempResponse.TempUploadDTO> imageUpload(@RequestPart("imageFiles")
-                                                             List<MultipartFile> images) {
+    public ApiResponse<TempResponse.TempUploadDTO> imageUpload(
+            @RequestPart(value = "imageFiles", required = false) List<MultipartFile> images) {
         TempResponse.TempUploadDTO tempUploadDTO =
                 tempQueryService.uploadImages("test", images);
         return ApiResponse.onSuccess(tempUploadDTO);

--- a/src/main/java/com/prototyne/Users/web/dto/MyProductDto.java
+++ b/src/main/java/com/prototyne/Users/web/dto/MyProductDto.java
@@ -3,6 +3,7 @@ package com.prototyne.Users.web.dto;
 import com.prototyne.domain.enums.InvestmentShipping;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder
@@ -39,8 +40,8 @@ public class MyProductDto {
         private CommonDto commonInfo;
         private InvestmentShipping shipping;    // 배송 상태 (Investment)
         private String transportNum;            // 운송장 번호 (Investment)
-        private LocalDateTime feedbackStart;    // 후기작성 시작시간 (Event)
-        private LocalDateTime feedbackEnd;      // 후기작성 마감시간 (Event)
+        private LocalDate feedbackStart;    // 후기작성 시작시간 (Event)
+        private LocalDate feedbackEnd;      // 후기작성 마감시간 (Event)
     }
 
     @Builder

--- a/src/main/java/com/prototyne/Users/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Users/web/dto/ProductDTO.java
@@ -5,6 +5,7 @@ import com.prototyne.domain.enums.InvestmentStatus;
 import com.prototyne.domain.enums.ProductCategory;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -63,15 +64,15 @@ public class ProductDTO {
     @Getter
     @Builder
     public static class DateInfo {
-        private LocalDateTime eventStart;
-        private LocalDateTime eventEnd;
-        private LocalDateTime releaseStart;
-        private LocalDateTime releaseEnd;
-        private LocalDateTime feedbackStart;
-        private LocalDateTime feedbackEnd;
+        private LocalDate eventStart;
+        private LocalDate eventEnd;
+        private LocalDate releaseStart;
+        private LocalDate releaseEnd;
+        private LocalDate feedbackStart;
+        private LocalDate feedbackEnd;
         private LocalDateTime judgeStart;
         private LocalDateTime judgeEnd;
-        private LocalDateTime endDate;
+        private LocalDate endDate;
     }
 
     @Getter

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -33,7 +33,6 @@ public enum ErrorStatus implements BaseErrorCode {
     OCCUPATION_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "ADDINFO4001", "잘못된 occupation 형식입니다."),
     PHONES_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "ADDINFO4001", "잘못된 phones 형식입니다."),
 
-
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
 
     // 로그인하지 않은 사용자가 북마크 여부 변경시
@@ -74,7 +73,10 @@ public enum ErrorStatus implements BaseErrorCode {
     ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다."),
 
     // 기업이 가지지 않은 시제품을 조회했을 경우
-    ENTERPRISE_ERROR_PRODUCT(HttpStatus.BAD_REQUEST, "ENTERPRISE4002", "존재하지 않는 기업의 시제품입니다.");
+    ENTERPRISE_ERROR_PRODUCT(HttpStatus.BAD_REQUEST, "ENTERPRISE4002", "존재하지 않는 기업의 시제품입니다."),
+
+    // 업로드할 이미지 개수가 초과될 경우
+    IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드할 이미지 개수 초과");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -65,7 +65,9 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다."),
 
     // 이벤트의 날짜가 null로 설정된 경우
-    EVENT_ERROR_DATE(HttpStatus.BAD_REQUEST,"EVENT4002","이벤트의 날짜가 null 입니다.");
+    EVENT_ERROR_DATE(HttpStatus.BAD_REQUEST,"EVENT4002","이벤트의 날짜가 null 입니다."),
+    // 존재하지 않은 기업일 경우
+    ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -52,6 +52,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     PRODUCT_ERROR_ID(HttpStatus.BAD_REQUEST, "PRODUCT4004", "존재하지 않는 시제품입니다."),
 
+    // 시제품 삭제 시, 시제품에 연결된 eventList가 비어있지 않은 경우
+    PRODUCT_ERROR_EVENTLIST(HttpStatus.BAD_REQUEST, "PRODUCT4005", "시제품에 대한 체험이 존재합니다."),
+
     INVESTMENT_ERROR_ID(HttpStatus.BAD_REQUEST, "INVESTMENT4001", "존재하지 않는 나의 시제품입니다."),
 
     FEEDBACK_ERROR_ID(HttpStatus.BAD_REQUEST, "FEEDBACK4001", "존재하지 않는 체험 후기입니다."),
@@ -66,8 +69,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 이벤트의 날짜가 null로 설정된 경우
     EVENT_ERROR_DATE(HttpStatus.BAD_REQUEST,"EVENT4002","이벤트의 날짜가 null 입니다."),
+
     // 존재하지 않은 기업일 경우
-    ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다.");
+    ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다."),
+
+    // 기업이 가지지 않은 시제품을 조회했을 경우
+    ENTERPRISE_ERROR_PRODUCT(HttpStatus.BAD_REQUEST, "ENTERPRISE4002", "존재하지 않는 기업의 시제품입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -69,6 +69,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 이벤트의 날짜가 null로 설정된 경우
     EVENT_ERROR_DATE(HttpStatus.BAD_REQUEST,"EVENT4002","이벤트의 날짜가 null 입니다."),
 
+    // 이벤트가 존재하지 않은 경우
+    EVENT_ERROR_ID(HttpStatus.BAD_REQUEST,"EVENT4003","존재하지 않은 이벤트 입니다."),
+
     // 존재하지 않은 기업일 경우
     ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다."),
 

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -38,7 +38,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 로그인하지 않은 사용자가 북마크 여부 변경시
     HEART_ERROR_ID(HttpStatus.BAD_REQUEST, "HEART4001", "로그인이 필요합니다"),
-    // 존재하지 않는 이gi벤트의 북마크 여부 변경시
+    // 존재하지 않는 이벤트의 북마크 여부 변경시
     HEART_ERROR_EVENT(HttpStatus.BAD_REQUEST, "HEART4002", "잘못된 이벤트 접근입니다"),
 
     DATE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "FORMAT4001", "잘못된 날짜 형식입니다. 올바른 형식: yyyy-MM-dd"),
@@ -62,7 +62,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     TiCKET_LACK_ERROR(HttpStatus.BAD_REQUEST, "TiCKET4001", "티켓이 부족합니다."),
 
-    EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다.");
+    EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다."),
+
+    // 이벤트의 날짜가 null로 설정된 경우
+    EVENT_ERROR_DATE(HttpStatus.BAD_REQUEST,"EVENT4002","이벤트의 날짜가 null 입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -73,7 +73,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다."),
 
     // 기업이 가지지 않은 시제품을 조회했을 경우
-    ENTERPRISE_ERROR_PRODUCT(HttpStatus.BAD_REQUEST, "ENTERPRISE4002", "존재하지 않는 기업의 시제품입니다."),
+    ENTERPRISE_ERROR_PRODUCT(HttpStatus.BAD_REQUEST, "ENTERPRISE4002", "기업이 등록하지 않은 시제품입니다."),
 
     // 업로드할 이미지 개수가 초과될 경우
     IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드할 이미지 개수 초과");

--- a/src/main/java/com/prototyne/apiPayload/config/SwaggerBeanConfig.java
+++ b/src/main/java/com/prototyne/apiPayload/config/SwaggerBeanConfig.java
@@ -1,0 +1,18 @@
+package com.prototyne.apiPayload.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import java.util.ArrayList;
+
+@Configuration
+public class SwaggerBeanConfig {
+
+    public SwaggerBeanConfig(MappingJackson2HttpMessageConverter converter) {
+        // Content-Type에 ctetstream 허용
+        var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+        converter.setSupportedMediaTypes(supportedMediaTypes);
+    }
+}

--- a/src/main/java/com/prototyne/domain/Alarm.java
+++ b/src/main/java/com/prototyne/domain/Alarm.java
@@ -4,7 +4,7 @@ import com.prototyne.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 
 @Entity
@@ -24,7 +24,7 @@ public class Alarm extends BaseEntity {
     private String contents;
 
     @Column(nullable = false)
-    private LocalDateTime StartReview; //후기 작성해야 하는 기간에 알람
+    private LocalDate StartReview; //후기 작성해야 하는 기간에 알람
 
     @Column
     private String thumbnailUrl;

--- a/src/main/java/com/prototyne/domain/Event.java
+++ b/src/main/java/com/prototyne/domain/Event.java
@@ -39,14 +39,12 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private LocalDate feedbackEnd;
 
-    // 심사 중 필드
-    @Column(nullable = true)
-    private LocalDateTime judgeStart;
-    @Column(nullable = true)
-    private LocalDateTime judgeEnd;
-    @Column(nullable = true)
-    private LocalDate endDate;
-    //
+//    @Column(nullable = true)
+//    private LocalDateTime judgeStart;
+//    @Column(nullable = true)
+//    private LocalDateTime judgeEnd;
+//    @Column(nullable = true)
+//    private LocalDate endDate;
 
     @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name="product_id")

--- a/src/main/java/com/prototyne/domain/Event.java
+++ b/src/main/java/com/prototyne/domain/Event.java
@@ -38,11 +38,12 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime feedbackEnd;
 
+    // 심사 중 필드
     @Column(nullable = false)
     private LocalDateTime judgeStart;
-
     @Column(nullable = false)
     private LocalDateTime judgeEnd;
+    //
 
     @Column(nullable = false)
     private LocalDateTime endDate;

--- a/src/main/java/com/prototyne/domain/Event.java
+++ b/src/main/java/com/prototyne/domain/Event.java
@@ -5,6 +5,7 @@ import com.prototyne.domain.mapping.Heart;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,32 +22,31 @@ public class Event extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private LocalDateTime eventStart;
+    private LocalDate eventStart;
 
     @Column(nullable = false)
-    private LocalDateTime eventEnd;
+    private LocalDate eventEnd;
 
     @Column(nullable = false)
-    private LocalDateTime releaseStart;
+    private LocalDate releaseStart;
 
     @Column(nullable = false)
-    private LocalDateTime releaseEnd;
+    private LocalDate releaseEnd;
 
     @Column(nullable = false)
-    private LocalDateTime feedbackStart;
+    private LocalDate feedbackStart;
 
     @Column(nullable = false)
-    private LocalDateTime feedbackEnd;
+    private LocalDate feedbackEnd;
 
     // 심사 중 필드
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDateTime judgeStart;
-    @Column(nullable = false)
+    @Column(nullable = true)
     private LocalDateTime judgeEnd;
+    @Column(nullable = true)
+    private LocalDate endDate;
     //
-
-    @Column(nullable = false)
-    private LocalDateTime endDate;
 
     @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name="product_id")

--- a/src/main/java/com/prototyne/domain/Product.java
+++ b/src/main/java/com/prototyne/domain/Product.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/prototyne/domain/Product.java
+++ b/src/main/java/com/prototyne/domain/Product.java
@@ -18,7 +18,7 @@ public class Product extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 15)
     private String name;
 
     @Column(nullable = false, length = 200)

--- a/src/main/java/com/prototyne/domain/Product.java
+++ b/src/main/java/com/prototyne/domain/Product.java
@@ -58,6 +58,6 @@ public class Product extends BaseEntity {
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Event> eventList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductImage> productImageList = new ArrayList<>();
 }

--- a/src/main/java/com/prototyne/domain/Product.java
+++ b/src/main/java/com/prototyne/domain/Product.java
@@ -54,7 +54,7 @@ public class Product extends BaseEntity {
     @JoinColumn(name = "enterprise_id")
     private Enterprise enterprise;
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Event> eventList = new ArrayList<>();
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)

--- a/src/main/java/com/prototyne/repository/EventRepository.java
+++ b/src/main/java/com/prototyne/repository/EventRepository.java
@@ -9,9 +9,8 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
@@ -24,19 +23,19 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             "WHERE e.eventStart <= :now AND e.eventEnd >= :now " +
             "GROUP BY e " +
             "ORDER BY (COUNT(h) + COUNT(i)) / 2 DESC")
-    List<Event> findAllActiveEventsByPopular(@Param("now") LocalDateTime now);
+    List<Event> findAllActiveEventsByPopular(@Param("now") LocalDate now);
 
     // 마감 임박순의 체험 진행 중인 이벤트
     @Query("SELECT e FROM Event e " +
             "WHERE e.eventStart <= :now AND e.eventEnd >= :now " +
             "ORDER BY e.eventEnd ASC")
-    List<Event> findAllEventsByImminent(@Param("now") LocalDateTime now);
+    List<Event> findAllEventsByImminent(@Param("now") LocalDate now);
 
     // 신규 등록순의 체험 진행 중인 이벤트
     @Query("SELECT e FROM Event e " +
             "WHERE e.eventStart <= :now AND e.eventEnd >= :now " +
             "ORDER BY e.eventStart DESC")
-    List<Event> findAllEventsByNew(@Param("now") LocalDateTime now);
+    List<Event> findAllEventsByNew(@Param("now") LocalDate now);
 
     // 검색(제품)명을 포함하는 이벤트
     List<Event> findAllByProductNameContaining(String name);

--- a/src/main/java/com/prototyne/repository/EventRepository.java
+++ b/src/main/java/com/prototyne/repository/EventRepository.java
@@ -44,5 +44,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     // 카테고리에 따른 이벤트
     List<Event> findByProductCategory(ProductCategory category);
 
-    // 시제품 이벤트 id
+    // 기업 ID로 모든 이벤트 조회 (조인)
+    @Query("SELECT e FROM Event e JOIN FETCH e.product p WHERE p.enterprise.id = :enterpriseId")
+    List<Event> findByEnterpriseId(Long enterpriseId);
 }

--- a/src/main/java/com/prototyne/repository/ProductRepository.java
+++ b/src/main/java/com/prototyne/repository/ProductRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    // 기업 ID로 모든 시제품 조회
     List<Product> findByEnterpriseId(Long enterpriseId);
 }

--- a/src/main/java/com/prototyne/repository/ProductRepository.java
+++ b/src/main/java/com/prototyne/repository/ProductRepository.java
@@ -4,6 +4,9 @@ import com.prototyne.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findByEnterpriseId(Long enterpriseId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,7 @@ swagger:
     alarm: '10. 알림'
     enterprise-auth: '11. 기업 로그인/회원가입'
     enterprise-product: '12. 기업 시제품 - 조회, 등록, 삭제'
+    enterprise-event: '13. 기업 체험(이벤트) - 조회, 등록, 삭제'
     test: 'A. Test API'
 
 spring-doc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,6 +106,7 @@ swagger:
     like: '09. 좋아요(북마크)'
     alarm: '10. 알림'
     enterprise-auth: '11. 기업 로그인/회원가입'
+    enterprise-product: '12. 기업 시제품 - 조회, 등록, 삭제'
     test: 'A. Test API'
 
 spring-doc:


### PR DESCRIPTION
## 📌 관련 이슈
#120, #121 (121 issue 아직 미완)

## ✨ PR 내용

1.  #120 브랜치 머지 (시제품 목록 조회 api 구현, 체험 목록 조회 api 구현)

2. 시제품 삭제 api 구현
![image](https://github.com/user-attachments/assets/dc8d2aeb-e5c0-471e-bc2f-09b81c480b2b)
시제품 삭제 실패 - 연결된 체험 있을 때
![image](https://github.com/user-attachments/assets/3db20298-ca91-4277-8c83-dfd269716b02)
시제품 삭제 완료 - 연결된 이미지까지 삭제

3. 시제품 등록 api (사진 업로드) 구현
![image](https://github.com/user-attachments/assets/8c6f62cc-c0a2-4935-9214-f9ddd3eb016c)
s3 업로드 완료

4. 체험 등록 api 구현
![image](https://github.com/user-attachments/assets/3c87a043-dfaf-4b57-8893-856f661c8a3c)
엔티티 수정으로 스웨거상 에러

6. 체험 엔티티 수정
![image](https://github.com/user-attachments/assets/3cd16a43-1668-4d78-9955-da0e9b59c793)
해당 필드 삭제

7. 체험 정보 조회 api 구현
![image](https://github.com/user-attachments/assets/8b1b77ba-7855-4112-a97d-1304794325bd)
