### PR TITLE
[Feat] 시제품/체험 삭제 api 구현

### DIFF
--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventService.java
@@ -13,4 +13,7 @@ public interface EventService {
 
     // 체험 정보 상세 조회
     EventDTO.EventInfo getEventInfo(String accessToken, Long eventId);
+
+    // 체험 삭제
+    void deleteEvent(String accessToken, Long eventId);
 }

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
@@ -78,4 +78,24 @@ public class EventServiceImpl implements EventService {
 
         return EventConverter.toEventInfo(product, event);
     }
+
+    // 체험 삭제
+    @Override
+    public void deleteEvent(String accessToken, Long eventId) {
+        Long enterpriseId = jwtManager.validateJwt(accessToken);
+
+        // 체험 객체 조회
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.EVENT_ERROR_ID));
+
+        // 이벤트로부터 제품 객체 가져오기
+        Product product = event.getProduct();
+
+        // 해당 시제품을 기업이 가졌는지 확인
+        if (!product.getEnterprise().getId().equals(enterpriseId))
+            throw new TempHandler(ErrorStatus.ENTERPRISE_ERROR_PRODUCT);
+
+        // 체험 삭제
+        eventRepository.delete(event);
+    }
 }

--- a/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Enterprise/service/EventService/EventServiceImpl.java
@@ -95,6 +95,10 @@ public class EventServiceImpl implements EventService {
         if (!product.getEnterprise().getId().equals(enterpriseId))
             throw new TempHandler(ErrorStatus.ENTERPRISE_ERROR_PRODUCT);
 
+        // 해당 체험에 연결된 투자가 있는지 확인
+        if (!event.getInvestmentList().isEmpty())
+            throw new TempHandler(ErrorStatus.EVENT_ERROR_INVESTMENT);
+
         // 체험 삭제
         eventRepository.delete(event);
     }

--- a/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
@@ -62,7 +62,7 @@ public class EventController {
     @GetMapping("/events/{eventId}")
     @Operation(summary = "체험 정보 조회 API - 인증 필수",
             description = """
-                    체험 상세 조회 \n 
+                    체험 상세 조회 \n
                     eventId 입력""",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<EventDTO.EventInfo> getEvent(HttpServletRequest token, @PathVariable Long eventId) {
@@ -74,10 +74,11 @@ public class EventController {
     // 체험 삭제
     @DeleteMapping("/events/{eventId}")
     @Operation(summary = "체험 삭제 API - 인증 필수",
-            description = "구현 중",
+            description = "체험 삭제 \n eventId 입력",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<String> deleteEvent(HttpServletRequest token, @PathVariable Long eventId) {
         String oauthToken = jwtManager.getToken(token);
+        eventService.deleteEvent(oauthToken, eventId);
         return ApiResponse.onSuccess("삭제 성공");
     }
 }

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -65,7 +65,7 @@ public class ProductController {
 
     // 시제품 삭제
     @DeleteMapping("/products/{productId}")
-    @Operation(summary = "시제품 등록 API - 인증 필수",
+    @Operation(summary = "시제품 삭제 API - 인증 필수",
             description = """
                     시제품 삭제 \n
                     productId 입력 \n

--- a/src/main/java/com/prototyne/Users/service/FeedbackService/FeedbackServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/FeedbackService/FeedbackServiceImpl.java
@@ -81,7 +81,7 @@ public class FeedbackServiceImpl implements FeedbackService {
         });
 
         // Amazon S3에 이미지 업로드
-        List<String> imageUrls = s3Manager.uploadFile(directory, feedbackImages);
+        List<String> imageUrls = s3Manager.uploadFiles(directory, feedbackImages);
 
         for (String imageUrl : imageUrls) {
             FeedbackImage feedbackImage = FeedbackImage.builder()

--- a/src/main/java/com/prototyne/Users/service/TempService/TempCommandServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/TempService/TempCommandServiceImpl.java
@@ -29,7 +29,7 @@ public class TempCommandServiceImpl implements TempCommandService {
         if (images == null) images = new ArrayList<>();
 
         // S3에 이미지 업로드
-        List<String> imageUrls = s3Manager.uploadFile(directory, images);
+        List<String> imageUrls = s3Manager.uploadFiles(directory, images);
 
         // DTO 생성 (URL 리스트를 포함한 DTO)
         return TempResponse.TempUploadDTO.builder()

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -76,7 +76,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다."),
 
     // 기업이 가지지 않은 시제품을 조회했을 경우
-    ENTERPRISE_ERROR_PRODUCT(HttpStatus.BAD_REQUEST, "ENTERPRISE4002", "기업이 등록하지 않은 시제품입니다."),
+    ENTERPRISE_ERROR_PRODUCT(HttpStatus.BAD_REQUEST, "ENTERPRISE4002", "다른 기업의 시제품입니다."),
 
     // 업로드할 이미지 개수가 초과될 경우
     IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드할 이미지 개수 초과");

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -72,6 +72,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 이벤트가 존재하지 않은 경우
     EVENT_ERROR_ID(HttpStatus.BAD_REQUEST,"EVENT4003","존재하지 않은 이벤트 입니다."),
 
+    // 이벤트에 유저가 투자했을 경우
+    EVENT_ERROR_INVESTMENT(HttpStatus.BAD_REQUEST,"EVENT4004","유저가 투자하고 있는 체험입니다."),
+
     // 존재하지 않은 기업일 경우
     ENTERPRISE_ERROR_ID(HttpStatus.BAD_REQUEST, "ENTERPRISE4001", "존재하지 않는 기업입니다."),
 


### PR DESCRIPTION
## 📌 관련 이슈
#121

## ✨ PR 내용
### 시제품 삭제 (delete enterprise/products/{productId}) - S3 이미지도 같이 삭제 기능 추가
![image](https://github.com/user-attachments/assets/3cc29166-e9aa-4914-a1fa-6d7c6073bfd3)
시제품 이미지 추가해서 등록 하면

![image](https://github.com/user-attachments/assets/bfa982cf-1cad-4715-8ffc-1ba1205ec7f5)
S3에 이미지 등록

![image](https://github.com/user-attachments/assets/1e4c762b-cad4-4869-a2b9-704d8cf9ecc9)
시제품 삭제 성공하면

![image](https://github.com/user-attachments/assets/fd15eb73-c4ef-4417-9853-0b1dd0b9877a)
S3의 이미지 삭제 + 테이블도 삭제

![image](https://github.com/user-attachments/assets/f499f5b1-887c-48f8-b3c5-beb1afc4a000)
삭제 실패1 - 다른 기업의 시제품의 시제품 삭제

![image](https://github.com/user-attachments/assets/a8d7fc2a-7ebf-4e74-9580-9c4a161308f8)
삭제 실패2 - 없는 시제품 아이디 삭제




### 체험 삭제 (delete enterprise/events/{eventId})
![image](https://github.com/user-attachments/assets/f0fffc91-bf17-453a-b7a4-015cd56e5994)
삭제 성공

![image](https://github.com/user-attachments/assets/a0129f6a-e3ab-4ad6-9dc7-d0f952e581f0)
삭제 실패1 - 다른 기업의 시제품의 체험 삭제

![image](https://github.com/user-attachments/assets/aa90ad7a-a51b-410c-bd94-219f129d2931)
삭제 실패2 - 없는 체험 아이디 삭제

