### PR TITLE
[Bug] 시제품 생성 api 컨트롤러 수정

### DIFF
--- a/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/EventController.java
@@ -79,7 +79,9 @@ public class EventController {
     // 체험 삭제
     @DeleteMapping("/events/{eventId}")
     @Operation(summary = "체험 삭제 API - 인증 필수",
-            description = "체험 삭제 \n eventId 입력",
+            description = "체험 삭제" +
+                    "eventId 입력" +
+                    "체험(event)에 연결된 투자(investment)가 없어야 삭제 가능",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<String> deleteEvent(HttpServletRequest token, @PathVariable Long eventId) {
         String oauthToken = jwtManager.getToken(token);

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -54,7 +54,7 @@ public class ProductController {
                     요청 성공 시, 시제품 아이디(product_id) 반환""",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<Long> createProduct(HttpServletRequest token,
-                                    @Valid @RequestPart("productRequest") ProductDTO.CreateProductRequest productRequest,
+                                    @Valid @RequestBody ProductDTO.CreateProductRequest productRequest,
                                            @RequestPart(value = "imageFiles", required = false) List<MultipartFile> images){
         String oauthToken = jwtManager.getToken(token);
         Long productId = productService.createProduct(oauthToken, productRequest, images);


### PR DESCRIPTION
## 📌 관련 이슈
closed #157 

## ✨ PR 내용
# 시제품 생성 컨트롤러 Request 수정
![image](https://github.com/user-attachments/assets/e3ec3486-9247-4448-b451-cc18e4d31f8f)


# 체험 삭제 컨트롤러 주석 추가 - 체험(event)에 연결된 투자(investment)가 없어야 삭제 가능
![image](https://github.com/user-attachments/assets/559ad8fe-4368-4170-ba2d-5347de945de7)
