### PR TITLE
feat: 체험 신청 API 시속 제한 추가

### DIFF
--- a/src/main/java/com/prototyne/Users/service/ApplicationService/ApplicationServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/ApplicationService/ApplicationServiceImpl.java
@@ -55,45 +55,58 @@ public class ApplicationServiceImpl implements ApplicationService {
 
         int userTickets = ticketService.getTicketNumber(accessToken).getTicketNumber();
         int reqTickets = product.getReqTickets();
-
         boolean apply = userTickets >= reqTickets;
+
+        int eventSpeed= event.getSpeed();
+        int userSpeed=user.getSpeed();
+        boolean is_speed=userSpeed >=eventSpeed;
+
+
         if (investmentRepository.findFirstByUserIdAndEventId(userId, eventId).isPresent()) {
             throw new TempHandler(ErrorStatus.EVENT_USER_EXIST);
         }
 
         if (apply) {
-            // 변경된 ticket 객체를 저장소에 저장
-            TicketDto.TicketListDto ticketListDto = TicketDto.TicketListDto.builder()
-                    .createdAt(LocalDateTime.now())
-                    .name(ticketName)
-                    .ticketDesc(ticketDesc)
-                    .ticketChange(-reqTickets)
-                    .build();
+            if(is_speed) {
+                // 변경된 ticket 객체를 저장소에 저장
+                TicketDto.TicketListDto ticketListDto = TicketDto.TicketListDto.builder()
+                        .createdAt(LocalDateTime.now())
+                        .name(ticketName)
+                        .ticketDesc(ticketDesc)
+                        .ticketChange(-reqTickets)
+                        .build();
 
-            Investment investment = investmentConverter.toInvestment(user, event, apply);
+                Investment investment = investmentConverter.toInvestment(user, event, apply);
 
-            // TicketService를 사용하여 티켓 저장
-            ticketService.saveTicket(ticketListDto, user);
+                // TicketService를 사용하여 티켓 저장
+                ticketService.saveTicket(ticketListDto, user);
 
-            // 알람 추가
-            Alarm alarm = Alarm.builder()
-                    .user(user)
-                    .title("[시제품명] " + product.getName())
-                    .contents("제품 후기 작성 마감 하루 전입니다!")
-                    .thumbnailUrl(product.getThumbnailUrl())
-                    .StartReview(event.getFeedbackEnd().minusDays(1))
-                    .build();
+                //체험 신청 시, 해당 event의 시속만큼 사용자의 speed(시속) 차감
 
-            alarmRepository.save(alarm);
-            alarmRepository.save(Alarm.builder()
-                    .user(user)
-                    .title("티켓 사용")
-                    .contents("티켓 " + reqTickets + "개 사용 완료 - " + product.getName())
-                    .thumbnailUrl(product.getThumbnailUrl())
-                    .StartReview(LocalDate.now())
-                    .build());
+                // 알람 추가
+                Alarm alarm = Alarm.builder()
+                        .user(user)
+                        .title("[시제품명] " + product.getName())
+                        .contents("제품 후기 작성 마감 하루 전입니다!")
+                        .thumbnailUrl(product.getThumbnailUrl())
+                        .StartReview(event.getFeedbackEnd().minusDays(1))
+                        .build();
 
-            eventService.saveInvestment(investment);
+                alarmRepository.save(alarm);
+                alarmRepository.save(Alarm.builder()
+                        .user(user)
+                        .title("티켓 사용")
+                        .contents("티켓 " + reqTickets + "개 사용 완료 - " + product.getName())
+                        .thumbnailUrl(product.getThumbnailUrl())
+                        .StartReview(LocalDate.now())
+                        .build());
+
+                eventService.saveInvestment(investment);
+            }
+            else{
+                throw new TempHandler(ErrorStatus.USER_SPEED__LACK_ERROR);
+            }
+
         } else {
             throw new TempHandler(ErrorStatus.TiCKET_LACK_ERROR);
         }

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -68,6 +68,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     TiCKET_LACK_ERROR(HttpStatus.BAD_REQUEST, "TiCKET4001", "티켓이 부족합니다."),
 
+    USER_SPEED__LACK_ERROR(HttpStatus.BAD_REQUEST, "SPEED4001", "시속이 부족하여 신청이 불가합니다."),
+
     EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다."),
 
     // 이벤트의 날짜가 null로 설정된 경우

--- a/src/main/java/com/prototyne/domain/Event.java
+++ b/src/main/java/com/prototyne/domain/Event.java
@@ -38,6 +38,9 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private LocalDate feedbackEnd;
 
+    @Column(nullable = false)
+    private Integer speed; //시속
+
     @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name="product_id")
     private Product product;

--- a/src/main/java/com/prototyne/domain/User.java
+++ b/src/main/java/com/prototyne/domain/User.java
@@ -68,6 +68,9 @@ public class User extends BaseEntity {
     @Column(length = 50)
     private String detailAddress; // 상세 주소
 
+    @Column(nullable = false)
+    private Integer speed; //시속
+
     @ElementCollection(fetch = FetchType.LAZY)
     private List<String> recentSearchList = new ArrayList<>(); // 최근 검색어 10개 저장
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#168 
## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
1. User와 Event 엔티티에 speed 컬럼 추가
2. [07. [일반회원] 시제품 - 신청/리뷰]
    체험 신청 API에 시제품의 speed가 사용자가 갖고 있는 speed보다 높을 경우,
    "시속이 부족하여 신청이 불가합니다." 라는 에러 메시지 출력
## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

1. 사용자의 시속이 시제품의 시속 제한보다 높을 경우-> 체험 신청
![image](https://github.com/user-attachments/assets/227753bc-f4a6-4140-9ca8-58cd9e12b718)
2. 사용자의 시속이 시제품의 시속 제한보다 낮을 경우-> 에러 메시지 출력
![image](https://github.com/user-attachments/assets/e6340273-ebc7-4ba9-b9f5-a1423ab90477)
