### PR TITLE
[Feat] 이번 주에 등록한 시제품 없는 경우 에러 처리

### DIFF
--- a/src/main/java/com/prototyne/Users/service/EventService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/EventService/EventServiceImpl.java
@@ -75,9 +75,15 @@ public class EventServiceImpl implements EventService {
     public List<ProductDTO.EventDTO> getEventsByType(Long userId, String type, String cursor, Integer pageSize) {
 
         // 유저 아이디 확인
-        userRepository.findById(userId).orElseThrow(() -> new RuntimeException("해당하는 회원이 존재하지 않습니다."));
+        userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
 
         List<Event> events = eventRepository.findAllEventsByType(type, cursor, pageSize);
+
+        // 이번 주에 등록된 시제품이 없을 경우
+        if ("new".equals(type) && (events == null || events.isEmpty())) {
+            throw new TempHandler(ErrorStatus.PRODUCT_ERROR_NEW);
+        }
+
         return events.stream()
                 .map(event -> {
                     // 북마크 상태 확인

--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -49,12 +49,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 시제품 목록 조회 실패
     PRODUCT_ERROR_TYPE(HttpStatus.BAD_REQUEST, "PRODUCT4001", "유효한 정렬 기준(type)이 아닙니다. 허용된 값: popular, imminent, new"),
+    PRODUCT_ERROR_NEW(HttpStatus.BAD_REQUEST, "PRODUCT4002", "이번 주에 등록한 시제품이 없습니다."),
     // 시제품 카테고리 조회 실패
-    PRODUCT_ERROR_CATEGORY(HttpStatus.BAD_REQUEST, "PRODUCT4002", "존재하지 않는 카테고리입니다."),
+    PRODUCT_ERROR_CATEGORY(HttpStatus.BAD_REQUEST, "PRODUCT4003", "존재하지 않는 카테고리입니다."),
     // 시제품 상세보기 조회 실패
-    PRODUCT_ERROR_EVENT(HttpStatus.BAD_REQUEST, "PRODUCT4003", "존재하지 않는 이벤트입니다."),
+    PRODUCT_ERROR_EVENT(HttpStatus.BAD_REQUEST, "PRODUCT4004", "존재하지 않는 이벤트입니다."),
 
-    PRODUCT_ERROR_ID(HttpStatus.BAD_REQUEST, "PRODUCT4004", "존재하지 않는 시제품입니다."),
+    PRODUCT_ERROR_ID(HttpStatus.BAD_REQUEST, "PRODUCT4005", "존재하지 않는 시제품입니다."),
 
     // 시제품 삭제 시, 시제품에 연결된 eventList가 비어있지 않은 경우
     PRODUCT_ERROR_EVENTLIST(HttpStatus.BAD_REQUEST, "PRODUCT4005", "시제품에 대한 체험이 존재합니다."),

--- a/src/main/java/com/prototyne/repository/querydsl/EventRepositoryCustomImpl.java
+++ b/src/main/java/com/prototyne/repository/querydsl/EventRepositoryCustomImpl.java
@@ -35,13 +35,23 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
     @Override
     public List<Event> findAllEventsByLimit(String type, int limit) {
         QEvent event = QEvent.event;
+        JPAQuery<Event> query = jpaQueryFactory.selectFrom(event);
 
+        // new의 경우 일주일 조건
+        if ("new".equals(type)) {
+            LocalDate today = LocalDate.now();
+            LocalDate lastWeekSameDay = today.minusWeeks(1);
+
+            LocalDateTime startOfLastWeek = lastWeekSameDay.atStartOfDay();             // 시작
+            LocalDateTime endOfThisWeek = today.atTime(23, 59, 59);  // 끝
+
+            BooleanExpression weekCondition = event.createdAt.between(startOfLastWeek, endOfThisWeek);
+            query.where(weekCondition);
+        }
+
+        // 정렬 조건
         List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(event, type);
-
-        // 쿼리 작성: 커서 조건 제거
-        JPAQuery<Event> query = jpaQueryFactory
-                .selectFrom(event)
-                .orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[0]))
+        query.orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[0]))
                 .limit(limit); // 요청된 개수만큼 제한
 
         return query.fetch();
@@ -51,15 +61,27 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
     @Override
     public List<Event> findAllEventsByType(String type, String cursor, int pageSize) {
         QEvent event = QEvent.event;
+        JPAQuery<Event> query = jpaQueryFactory.selectFrom(event);
 
+        // new의 경우 일주일 조건
+        if ("new".equals(type)) {
+            LocalDate today = LocalDate.now();
+            LocalDate lastWeekSameDay = today.minusWeeks(1);
+
+            LocalDateTime startOfLastWeek = lastWeekSameDay.atStartOfDay();             // 시작
+            LocalDateTime endOfThisWeek = today.atTime(23, 59, 59);  // 끝
+
+            BooleanExpression weekCondition = event.createdAt.between(startOfLastWeek, endOfThisWeek);
+            query.where(weekCondition);
+        }
+
+        // 정렬 조건
         List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(event, type);
+        // 커서 조건
         BooleanExpression cursorCondition = getCursorCondition(event, type, cursor);
-
-        JPAQuery<Event> query = jpaQueryFactory
-                .selectFrom(event)
-                .where(cursorCondition)
+        query.where(cursorCondition)
                 .orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[0]))
-                .limit(pageSize); // 페이지 크기 제한
+                .limit(pageSize);
 
         return query.fetch();
     }


### PR DESCRIPTION
## 📌 관련 이슈
#167 

## ✨ PR 내용
이번 주에 등록한 시제품 없는 경우 에러 처리
### 홈화면 더보기 일 경우
![image](https://github.com/user-attachments/assets/8bcbe229-a74d-48f8-b687-b31d135f074c)
new 입력 시, 
![image](https://github.com/user-attachments/assets/f29a3196-7fc6-4685-a828-c7f3804ebdea)
에러 처리

### 홈화면
![image](https://github.com/user-attachments/assets/a0612614-2148-4838-9358-50a831422929)
![image](https://github.com/user-attachments/assets/669343e2-1694-4dd8-965d-013f9fa6bd3a)
빈 리슽스트 반환. 에러 처리면 위 인기, 마감이 반환을 못 받으므로