### PR TITLE
[Fix] 기업 시제품(Product) 등록 api 분리

### DIFF
--- a/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/EventConverter.java
@@ -36,8 +36,7 @@ public class EventConverter {
                 .product(product)
                 .eventStart(request.getEventStart())
                 .eventEnd(request.getEventEnd())
-                .releaseStart(request.getReleaseStart())
-                .releaseEnd(request.getReleaseEnd())
+                .releaseDate(request.getReleaseDate())
                 .feedbackStart(request.getFeedbackStart())
                 .feedbackEnd(request.getFeedbackEnd())
                 .build();
@@ -59,8 +58,7 @@ public class EventConverter {
         EventDTO.EventDate eventDate = EventDTO.EventDate.builder()
                 .eventStart(event.getEventStart())
                 .eventEnd(event.getEventEnd())
-                .releaseStart(event.getReleaseStart())
-                .releaseEnd(event.getReleaseEnd())
+                .releaseDate(event.getReleaseDate())
                 .feedbackStart(event.getFeedbackStart())
                 .feedbackEnd(event.getFeedbackEnd())
                 .build();
@@ -99,8 +97,8 @@ public class EventConverter {
     // 현재 날짜에 따라 체험(이벤트) 단계 계산
     private static Integer calculateStage(LocalDate now, Event event){
         if (now.isBefore(event.getEventStart())) return 1; // 시작 전
-        else if (now.isBefore(event.getReleaseStart())) return 2; // 신청자 모집 기간
-        else if (now.isBefore(event.getFeedbackStart())) return 3; // 당첨자 발표 기간
+        else if (now.isBefore(event.getReleaseDate())) return 2; // 신청자 모집 기간
+        else if (now.isBefore(event.getFeedbackStart())) return 3; // 당첨자 발표일
         else if (now.isBefore(event.getFeedbackEnd()) || now.isEqual(event.getFeedbackEnd()))
             return  4; // 후기 작성 기간
         else return 5; // 종료
@@ -114,7 +112,7 @@ public class EventConverter {
             case 2:
                 return event.getEventEnd(); // 신청자 모집 기간 -> 이벤트 종료일
             case 3:
-                return event.getReleaseEnd(); // 당첨자 발표 기간 -> 발표 종료일
+                return event.getReleaseDate(); // 당첨자 발표 기간 -> 발표일
             case 4:
                 return event.getFeedbackEnd(); // 후기 작성 기간 -> 작성 종료일
             case 5:

--- a/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Enterprise/converter/ProductConverter.java
@@ -27,8 +27,7 @@ public class ProductConverter {
     // 시제품 엔티티 형식으로
     public static Product toProduct(ProductDTO.ProductInfo req1,
                                     ProductDTO.Questions req2,
-                                    Enterprise enterprise,
-                                    List<String> imageUrls) {
+                                    Enterprise enterprise) {
         // Product 생성
         ProductDTO.ProductInfo productInfo = req1;
         ProductDTO.Questions questions = req2;
@@ -47,26 +46,6 @@ public class ProductConverter {
                 .question5(questions.getQuestion5())
                 .enterprise(enterprise)
                 .build();
-
-        // 이미지 업로드한 경우에만 ProductImage 생성
-        if (imageUrls != null && !imageUrls.isEmpty()) {
-            // imageList 초기화 후, imageUrlsList와 연결
-            if (newProduct.getProductImageList() == null) {
-                newProduct.setProductImageList(new ArrayList<>());
-            }
-
-            List<ProductImage> productImages = imageUrls.stream()
-                    .map(url -> ProductImage.builder()
-                            .imageUrl(url)
-                            .product(newProduct)
-                            .build())
-                    .toList();
-
-            newProduct.getProductImageList().addAll(productImages);
-
-            // 첫번째 이미지로 썸네일 설정
-            newProduct.setThumbnailUrl(productImages.get(0).getImageUrl());
-        }
 
         return newProduct;
     }

--- a/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
+++ b/src/main/java/com/prototyne/Enterprise/service/ProductService/ProductService.java
@@ -11,7 +11,10 @@ public interface ProductService {
     List<ProductDTO.ProductResponse> getProducts(String accessToken);
 
     // 기업 id로부터 시제품 등록 (토큰 인증 필수) - id 반환
-    Long createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest, List<MultipartFile> images);
+    Long createProduct(String accessToken, ProductDTO.CreateProductRequest productRequest);
+
+    // 기업 id로부터 시제품 등록 (토큰 인증 필수) - id 반환
+    List<String> createProductImages(String accessToken, Long productId, List<MultipartFile> images);
 
     // 기업 id가 가진 시제품 삭제
     void deleteProduct(String accessToken, Long productId);

--- a/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/Enterprise/web/controller/ProductController.java
@@ -43,7 +43,7 @@ public class ProductController {
     }
 
     // 시제품 등록
-    @Operation(summary = "시제품 등록 API - 인증 필수",
+    @Operation(summary = "[시제품 등록 1] 시제품 등록 API - 인증 필수",
             description = "시제품 등록(추가)" + """
 
                     1. 시제품 명 (productName) - 공백 시 에러
@@ -53,18 +53,32 @@ public class ProductController {
                     5. 카테고리 (category)
                     6. 출시예정일 (launchedDate) - 공백(null)이면 미정
                     7. 질문 목록 (1~5)
-                    8. imageFiles : 제품 사진 (최대 3장)
 
                     요청 성공 시, 시제품 아이디(product_id) 반환""",
             security = {@SecurityRequirement(name = "session-token")})
-    @PostMapping(value = "/products", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping("/products")
     public ApiResponse<Long> createProduct(HttpServletRequest token,
-                                           @Valid @RequestPart("productRequest") ProductDTO.CreateProductRequest productRequest,
-                                           @RequestPart(value = "imageFiles", required = false) List<MultipartFile> images)
-    {
+                                           @Valid @RequestBody ProductDTO.CreateProductRequest productRequest) {
         String oauthToken = jwtManager.getToken(token);
-        Long productId = productService.createProduct(oauthToken, productRequest, images);
+        Long productId = productService.createProduct(oauthToken, productRequest);
         return ApiResponse.onSuccess(productId);
+    }
+
+    // 시제품 이미지 등록
+    @Operation(summary = "[시제품 등록 2] 시제품 이미지 등록 API - 인증 필수",
+            description = "시제품 이미지 등록(추가)" + """
+
+                    1. 이미지 - 3장까지 등록 가능
+
+                    요청 성공 시, 시제품 아이디(product_id) 반환""",
+            security = {@SecurityRequirement(name = "session-token")})
+    @PostMapping(value = "/products/{productId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<List<String>> createProductImage(HttpServletRequest token,
+                                           @PathVariable Long productId,
+                                           @RequestPart(value = "imageFiles", required = false) List<MultipartFile> images) {
+        String oauthToken = jwtManager.getToken(token);
+        List<String> productImages = productService.createProductImages(oauthToken, productId, images);
+        return ApiResponse.onSuccess(productImages);
     }
 
     // 시제품 삭제

--- a/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
+++ b/src/main/java/com/prototyne/Enterprise/web/dto/EventDTO.java
@@ -18,10 +18,8 @@ public class EventDTO {
         private final LocalDate eventStart;     // 체험 시작
         @NotNull(message = "eventEnd가 공백입니다.")
         private final LocalDate eventEnd;       // 체험 마감
-        @NotNull(message = "releaseStart가 공백입니다.")
-        private final LocalDate releaseStart;   // 당첨자 시작
-        @NotNull(message = "releaseEnd가 공백입니다.")
-        private final LocalDate releaseEnd;     // 당첨자 종료
+        @NotNull(message = "releaseDate가 공백입니다.")
+        private final LocalDate releaseDate;    // 당첨자 발표
         @NotNull(message = "feedbackStart가 공백입니다.")
         private final LocalDate feedbackStart;  // 피드백 시작
         @NotNull(message = "feedbackEnd가 공백입니다.")

--- a/src/main/java/com/prototyne/Users/converter/MyProductConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/MyProductConverter.java
@@ -19,7 +19,7 @@ public class MyProductConverter {
     public MyProductDto.CommonDto toCommonDto(Investment investment) {
         Event event = investment.getEvent();
         Product product = event.getProduct();
-        LocalDate releaseStart = event.getReleaseStart();
+        LocalDate releaseStart = event.getReleaseDate();
         LocalDate now = LocalDate.now();
         String calculatedStatus;
 
@@ -47,7 +47,7 @@ public class MyProductConverter {
 
     public MyProductDto.AppliedDto toAppliedDto(Investment investment) {
         MyProductDto.CommonDto commonInfo = toCommonDto(investment);
-        LocalDate releaseStart = investment.getEvent().getReleaseStart();
+        LocalDate releaseStart = investment.getEvent().getReleaseDate();
         LocalDateTime now = LocalDateTime.now();
 
         // releaseStart - 현재 날짜

--- a/src/main/java/com/prototyne/Users/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/Users/converter/ProductConverter.java
@@ -46,7 +46,7 @@ public class ProductConverter {
                 .bookmark(bookmark)
                 .createdAt(event.getCreatedAt())
                 .eventEnd(event.getFeedbackEnd())
-                .releaseEnd(event.getReleaseEnd())
+                .releaseDate(event.getReleaseDate())
                 .speed(event.getSpeed())
                 .investCount(investCount)
                 .dDay(calculateDDay(now, event.getEventEnd())) // 디데이 계산
@@ -78,7 +78,6 @@ public class ProductConverter {
          ProductDTO.DateInfo dateInfo = toDateInfo(event);
          // 유저 투자 정보 DTO 객체 생성
          ProductDTO.InvestInfo investInfo = toInvestInfo(investment);
-         // Heart(북마크)목록에서 제품에 대한 사용자의 북마크 존재여부로 판단
 
          return  ProductDTO.EventDetailsResponse.builder()
                  .eventId(event.getId())
@@ -100,8 +99,7 @@ public class ProductConverter {
         return ProductDTO.DateInfo.builder()
                 .eventStart(event.getEventStart())
                 .eventEnd(event.getEventEnd())
-                .releaseStart(event.getReleaseStart())
-                .releaseEnd(event.getReleaseEnd())
+                .releaseDate(event.getReleaseDate())
                 .feedbackStart(event.getFeedbackStart())
                 .feedbackEnd(event.getFeedbackEnd())
                 .build();

--- a/src/main/java/com/prototyne/Users/service/MyProductService/MyProductServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/MyProductService/MyProductServiceImpl.java
@@ -39,7 +39,7 @@ public class MyProductServiceImpl implements MyProductService {
 
         return myProductRepository.findByUserId(userId).stream()
                 .filter(investment -> investment.getStatus() == InvestmentStatus.신청)
-                .filter(investment -> investment.getEvent().getReleaseStart().isAfter(now))
+                .filter(investment -> investment.getEvent().getReleaseDate().isAfter(now))
                 .map(myProductConverter::toAppliedDto)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/prototyne/Users/service/TicketService/TicketServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/TicketService/TicketServiceImpl.java
@@ -87,7 +87,7 @@ public class TicketServiceImpl implements TicketService {
         // appliedNum
         Integer appliedNum = (int) myProductRepository.findByUserId(userId).stream()
                 .filter(investment -> investment.getStatus() == InvestmentStatus.신청)
-                .filter(investment -> investment.getEvent().getReleaseStart().atStartOfDay().isAfter(now))
+                .filter(investment -> investment.getEvent().getReleaseDate().atStartOfDay().isAfter(now))
                 .count();
 
         // selectedNum

--- a/src/main/java/com/prototyne/Users/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/Users/web/dto/ProductDTO.java
@@ -32,10 +32,10 @@ public class ProductDTO {
         private Boolean bookmark;       // 유저의 북마크 여부
         private Integer reqTickets;     // 시제품 필요 티켓 수
         private Integer speed;          // 이벤트 시속 점수
-        private Integer investCount;    // 신청한 사람 수 -> 투자 테이블 수
-        private Integer dDay;           // 디데이(신청마감 기준, 프론트 처리?)
+        private Integer investCount;    // 신청한 사람 수
+        private Integer dDay;           // 디데이
         private LocalDate eventEnd;
-        private LocalDate releaseEnd;  // 당첨자 결과 발표일
+        private LocalDate releaseDate;
         private LocalDateTime createdAt;
     }
 
@@ -84,6 +84,7 @@ public class ProductDTO {
         private String contents;    // 시제품 설명
         private Boolean isBookmarked;   // 사용자의 북마크 여부
         private DateInfo dateInfo;  // 이벤트 날짜 정보
+        private LocalDate launchedDate; // 출시 예정일
         private InvestInfo investInfo;  // 유저 투자 정보
     }
 
@@ -92,8 +93,7 @@ public class ProductDTO {
     public static class DateInfo {
         private LocalDate eventStart;
         private LocalDate eventEnd;
-        private LocalDate releaseStart;
-        private LocalDate releaseEnd;
+        private LocalDate releaseDate;
         private LocalDate feedbackStart;
         private LocalDate feedbackEnd;
     }

--- a/src/main/java/com/prototyne/domain/Event.java
+++ b/src/main/java/com/prototyne/domain/Event.java
@@ -28,10 +28,7 @@ public class Event extends BaseEntity {
     private LocalDate eventEnd;
 
     @Column(nullable = false)
-    private LocalDate releaseStart;
-
-    @Column(nullable = false)
-    private LocalDate releaseEnd;
+    private LocalDate releaseDate;
 
     @Column(nullable = false)
     private LocalDate feedbackStart;

--- a/src/main/java/com/prototyne/repository/ProductImageRepository.java
+++ b/src/main/java/com/prototyne/repository/ProductImageRepository.java
@@ -1,0 +1,7 @@
+package com.prototyne.repository;
+
+import com.prototyne.domain.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
#179 

## ✨ PR 내용
### 1. Event 엔티티 - releaseStart, releaseEnd 삭제 / releaseDate 추가
그에 따른 DTO 및 코드 수정

### 2. 기업 시제품 등록 api 분리
![image](https://github.com/user-attachments/assets/30888ee0-a03c-4aa0-87f0-46f01a7969af)
두 메소드 모두 Transactional 처리 

![image](https://github.com/user-attachments/assets/68c1509b-683e-4062-b086-d387754902c8)
시제품 이미지 등록의 경우, @pathVariable로 productId 필요

- 시제품 등록 (1) - 이미지만 없는 시제품 정보 등록
<img width="725" alt="zoq1" src="https://github.com/user-attachments/assets/7b9d24a1-3bf6-4456-9ed1-515b04030d7e">
<img width="287" alt="zoq2" src="https://github.com/user-attachments/assets/70b3ba54-a260-494c-8298-2e03c04ffb86">

생성된 productId 반환


- 시제품 등록 (2) - 이미지 등록
<img width="716" alt="zoq3" src="https://github.com/user-attachments/assets/1272e781-becc-449b-89cd-ced6b14246b5">
<img width="502" alt="zoq4" src="https://github.com/user-attachments/assets/84caa3d0-9b2c-49ff-a797-0d0145786cef">
<img width="822" alt="zoq5" src="https://github.com/user-attachments/assets/a4e6f0ca-959b-45b0-b743-1a714f5c70d0">

반환받은 productId에 이미지 등록
<img width="743" alt="zoq6" src="https://github.com/user-attachments/assets/c4f41d0a-2cbb-4841-aa71-adc661fcc3b9">
썸네일 업데이트 완료


**_해당 브랜치는 충돌날 수도 있기에,, 마지막에 머지해주세요!_**