### PR TITLE
[FIX] 유저 카카오 로그인 에러

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,7 +2,7 @@ name: CICD
 
 on:
   push:
-    branches: [ "main", "bug/185" ]
+    branches: [ "main"]
 #  pull_request:
 #    branches: [ "main" ]
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,7 +2,7 @@ name: CICD
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "bug/185" ]
 #  pull_request:
 #    branches: [ "main" ]
 

--- a/src/main/java/com/prototyne/Users/service/LoginService/KakaoServiceImpl.java
+++ b/src/main/java/com/prototyne/Users/service/LoginService/KakaoServiceImpl.java
@@ -27,13 +27,19 @@ public class KakaoServiceImpl implements KakaoService {
     private final UserRepository userRepository;
     private final TokenService tokenService;
     private String clientId;
+    private String redirectUri;
 
     @Autowired
-    public KakaoServiceImpl(JwtManager jwtManager, UserRepository userRepository, TokenService tokenService, @Value("${spring.datasource.client-id}") String clientId) {
+    public KakaoServiceImpl(JwtManager jwtManager,
+                            UserRepository userRepository,
+                            TokenService tokenService,
+                            @Value("${spring.datasource.client-id}") String clientId,
+                            @Value("${spring.kakao.redirect-uri}") String redirectUri) {
         this.jwtManager = jwtManager;
         this.userRepository = userRepository;
         this.tokenService = tokenService;
         this.clientId = clientId;
+        this.redirectUri = redirectUri;
     }
 
     @Override
@@ -46,6 +52,7 @@ public class KakaoServiceImpl implements KakaoService {
                         .queryParam("grant_type", "authorization_code")
                         .queryParam("client_id", clientId)
                         .queryParam("code", code)
+                        .queryParam("redirect_uri", redirectUri)
                         .build(true))
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
                 .retrieve()

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -15,6 +15,7 @@ spring:
         static: ap-northeast-2
 
   kakao:
+    redirect-uri: ${KAKAO_REDIRECT_URI}
     pay:
       admin-key: ${KAKAO_PAY_ADMIN_KEY}
       secret-key: ${KAKAO_PAY_SECRET_KEY}


### PR DESCRIPTION
## 📌 관련 이슈
close #185 

## ✨ PR 내용
- redirect uri에 프론트 주소(/oauth)추가
![image](https://github.com/user-attachments/assets/29ab70ed-39f8-4183-81f8-2362058b811e)

하면서 ec2의 docker-compose-blue.yml에도 KAKAO_REDIRECT_URI=프론트주소/oauth 추가 (1)
.env 파일 업데이트 (2)
